### PR TITLE
[feat]: add elementary package

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -22,6 +22,10 @@ target-path: target  # directory which will store compiled SQL files
 clean-targets:  # directories to be removed by `dbt clean`
   - target
   - dbt_modules
+# Disable metadata models updates:
+vars:
+  disable_dbt_artifacts_autoupload: true
+
 # Grant acess
 # bq data control: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-control-language
 # dbt grant statements use https://discourse.getdbt.com/t/the-exact-grant-statements-we-use-in-a-dbt-project/430
@@ -298,3 +302,5 @@ models:
     test_dataset:
       +materialized: table
       +schema: test_dataset
+    elementary:
+      +schema: elementary

--- a/packages.yml
+++ b/packages.yml
@@ -2,3 +2,5 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: 1.1.1
+  - package: elementary-data/elementary
+    version: 0.14.0


### PR DESCRIPTION
- add elementary package to queries-basedosdados project
- disables materialization for unused  elementary tables
- ideally, all metadata from production tests/runs should be saved in the elementary dataset, but it includes an option to disable data materialization in the `Executa DBT model` pipeline. basedosdados/pipelines/pull/665