### PR TITLE
[fix]: fix `documentos_balancete` test

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -12,8 +12,8 @@ profile: default
 vars:
   disable_run_results: false
   disable_tests_results: false
-  disable_dbt_artifacts_autoupload: false
-  disable_dbt_invocation_autoupload: false
+  disable_dbt_artifacts_autoupload: true
+  disable_dbt_invocation_autoupload: true
 # These configurations specify where dbt should look for different types of files.
 # The `source-paths` config, for example, states that models in this project can be
 # found in the "models/" directory. You probably won't need to change these!

--- a/models/br_cvm_fi/schema.yml
+++ b/models/br_cvm_fi/schema.yml
@@ -9,6 +9,10 @@ models:
             - plano_contabil_balancete
             - codigo_conta
             - cnpj
+            - cnpj_basico
+            - ano
+            - mes
+            - saldo_conta
     description: O balancete é um documento gerado mensalmente pela contabilidade
       do fundo.
     columns:


### PR DESCRIPTION
closes #505 
Pequeno pr para corrigir o teste da tabela `documentos_balancete`
Resultado do teste corrigido em `dev`:
```bash
20:33:07  Running with dbt=1.5.6
20:33:10  Registered adapter: bigquery=1.5.6
20:33:12  Found 438 models, 1412 tests, 0 snapshots, 0 analyses, 1164 macros, 2 operations, 0 seed files, 0 sources, 0 exposures, 0 metrics, 0 groups
20:33:12
20:33:34
20:33:34  Running 1 on-run-start hook
20:33:35  1 of 1 START hook: elementary.on-run-start.0 ................................... [RUN]
20:33:35  1 of 1 OK hook: elementary.on-run-start.0 ...................................... [OK in 0.00s]
20:33:35
20:33:35  Concurrency: 2 threads (target='dev')
20:33:35
20:33:35  1 of 1 START test dbt_utils_unique_combination_of_columns_documentos_balancete_data_competencia__plano_contabil_balancete__codigo_conta__cnpj__ano__mes__saldo_conta  [RUN]
20:33:52  1 of 1 PASS dbt_utils_unique_combination_of_columns_documentos_balancete_data_competencia__plano_contabil_balancete__codigo_conta__cnpj__ano__mes__saldo_conta  [PASS in 17.22s]
20:33:52
20:33:52  Running 1 on-run-end hook
20:33:58  1 of 1 START hook: elementary.on-run-end.0 ..................................... [RUN]
20:33:58  1 of 1 OK hook: elementary.on-run-end.0 ........................................ [OK in 0.00s]
20:33:58
20:33:58
20:33:58  Finished running 1 test, 2 hooks in 0 hours 0 minutes and 46.38 seconds (46.38s).
20:33:59
20:33:59  Completed successfully
20:33:59
20:33:59  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

