### PR TITLE
[fix] br_ibge_

### DIFF
--- a/models/br_ibge_ipca/br_ibge_ipca__mes_brasil.sql
+++ b/models/br_ibge_ipca/br_ibge_ipca__mes_brasil.sql
@@ -10,6 +10,11 @@
         ],
     )
 }}
+
+with
+    drop_duplicates as (
+        select distinct * from `basedosdados-staging.br_ibge_ipca_staging.mes_brasil`
+    )
 select
     safe_cast(ano as int64) ano,
     safe_cast(mes as int64) mes,
@@ -19,7 +24,7 @@ select
     safe_cast(variacao_semestral as float64) variacao_semestral,
     safe_cast(variacao_anual as float64) variacao_anual,
     safe_cast(variacao_doze_meses as float64) variacao_doze_meses
-from `basedosdados-staging.br_ibge_ipca_staging.mes_brasil` as t
+from drop_duplicates as t
 
 {% if is_incremental() %}
     where

--- a/models/br_ibge_ipca/br_ibge_ipca__mes_categoria_brasil.sql
+++ b/models/br_ibge_ipca/br_ibge_ipca__mes_categoria_brasil.sql
@@ -18,7 +18,7 @@ with
         from `basedosdados-staging.br_ibge_ipca_staging.mes_categoria_brasil`
     )
 
-select distinct
+select
     safe_cast(ano as int64) ano,
     safe_cast(mes as int64) mes,
     safe_cast(id_categoria as string) id_categoria,

--- a/models/br_ibge_ipca/br_ibge_ipca__mes_categoria_brasil.sql
+++ b/models/br_ibge_ipca/br_ibge_ipca__mes_categoria_brasil.sql
@@ -10,7 +10,15 @@
         ],
     )
 }}
-select
+
+
+with
+    drop_duplicates as (
+        select distinct *
+        from `basedosdados-staging.br_ibge_ipca_staging.mes_categoria_brasil`
+    )
+
+select distinct
     safe_cast(ano as int64) ano,
     safe_cast(mes as int64) mes,
     safe_cast(id_categoria as string) id_categoria,
@@ -20,7 +28,7 @@ select
     safe_cast(variacao_mensal as float64) variacao_mensal,
     safe_cast(variacao_anual as float64) variacao_anual,
     safe_cast(variacao_doze_meses as float64) variacao_doze_meses
-from `basedosdados-staging.br_ibge_ipca_staging.mes_categoria_brasil` as t
+from drop_duplicates as t
 {% if is_incremental() %}
     where
         date(cast(ano as int64), cast(mes as int64), 1)

--- a/models/br_ibge_ipca/br_ibge_ipca__mes_categoria_municipio.sql
+++ b/models/br_ibge_ipca/br_ibge_ipca__mes_categoria_municipio.sql
@@ -10,6 +10,12 @@
         ],
     )
 }}
+
+with
+    drop_duplicates as (
+        select distinct *
+        from `basedosdados-staging.br_ibge_ipca_staging.mes_categoria_municipio`
+    )
 select
     safe_cast(ano as int64) ano,
     safe_cast(mes as int64) mes,
@@ -21,7 +27,7 @@ select
     safe_cast(variacao_mensal as float64) variacao_mensal,
     safe_cast(variacao_anual as float64) variacao_anual,
     safe_cast(variacao_doze_meses as float64) variacao_doze_meses
-from `basedosdados-staging.br_ibge_ipca_staging.mes_categoria_municipio` as t
+from drop_duplicates as t
 {% if is_incremental() %}
     where
         date(cast(ano as int64), cast(mes as int64), 1)

--- a/models/br_ibge_ipca/br_ibge_ipca__mes_categoria_rm.sql
+++ b/models/br_ibge_ipca/br_ibge_ipca__mes_categoria_rm.sql
@@ -11,6 +11,12 @@
     )
 }}
 
+
+with
+    drop_duplicates as (
+        select distinct *
+        from `basedosdados-staging.br_ibge_ipca_staging.mes_categoria_rm`
+    )
 select
     safe_cast(ano as int64) ano,
     safe_cast(mes as int64) mes,
@@ -22,7 +28,7 @@ select
     safe_cast(variacao_mensal as float64) variacao_mensal,
     safe_cast(variacao_anual as float64) variacao_anual,
     safe_cast(variacao_doze_meses as float64) variacao_doze_meses
-from `basedosdados-staging.br_ibge_ipca_staging.mes_categoria_rm` as t
+from drop_duplicates as t
 {% if is_incremental() %}
     where
         date(cast(ano as int64), cast(mes as int64), 1)

--- a/models/br_ibge_ipca15/br_ibge_ipca15__mes_brasil.sql
+++ b/models/br_ibge_ipca15/br_ibge_ipca15__mes_brasil.sql
@@ -10,6 +10,12 @@
         ],
     )
 }}
+
+
+with
+    drop_duplicates as (
+        select distinct * from `basedosdados-staging.br_ibge_ipca15_staging.mes_brasil`
+    )
 select
     safe_cast(ano as int64) ano,
     safe_cast(mes as int64) mes,
@@ -19,7 +25,7 @@ select
     safe_cast(variacao_semestral as float64) variacao_semestral,
     safe_cast(variacao_anual as float64) variacao_anual,
     safe_cast(variacao_doze_meses as float64) variacao_doze_meses
-from `basedosdados-staging.br_ibge_ipca15_staging.mes_brasil` as t
+from drop_duplicates as t
 {% if is_incremental() %}
     where
         date(cast(ano as int64), cast(mes as int64), 1)

--- a/models/br_ibge_ipca15/br_ibge_ipca15__mes_categoria_brasil.sql
+++ b/models/br_ibge_ipca15/br_ibge_ipca15__mes_categoria_brasil.sql
@@ -10,6 +10,12 @@
         ],
     )
 }}
+
+with
+    drop_duplicates as (
+        select distinct *
+        from `basedosdados-staging.br_ibge_ipca15_staging.mes_categoria_brasil`
+    )
 select
     safe_cast(ano as int64) ano,
     safe_cast(mes as int64) mes,
@@ -20,7 +26,7 @@ select
     safe_cast(variacao_mensal as float64) variacao_mensal,
     safe_cast(variacao_anual as float64) variacao_anual,
     safe_cast(variacao_doze_meses as float64) variacao_doze_meses
-from `basedosdados-staging.br_ibge_ipca15_staging.mes_categoria_brasil` as t
+from drop_duplicates as t
 {% if is_incremental() %}
     where
         date(cast(ano as int64), cast(mes as int64), 1)

--- a/models/br_ibge_ipca15/br_ibge_ipca15__mes_categoria_municipio.sql
+++ b/models/br_ibge_ipca15/br_ibge_ipca15__mes_categoria_municipio.sql
@@ -10,6 +10,12 @@
         ],
     )
 }}
+
+with
+    drop_duplicates as (
+        select distinct *
+        from `basedosdados-staging.br_ibge_ipca15_staging.mes_categoria_municipio`
+    )
 select
     safe_cast(ano as int64) ano,
     safe_cast(mes as int64) mes,
@@ -21,7 +27,7 @@ select
     safe_cast(variacao_mensal as float64) variacao_mensal,
     safe_cast(variacao_anual as float64) variacao_anual,
     safe_cast(variacao_doze_meses as float64) variacao_doze_meses
-from `basedosdados-staging.br_ibge_ipca15_staging.mes_categoria_municipio` as t
+from drop_duplicates as t
 {% if is_incremental() %}
     where
         date(cast(ano as int64), cast(mes as int64), 1)

--- a/models/br_ibge_ipca15/br_ibge_ipca15__mes_categoria_rm.sql
+++ b/models/br_ibge_ipca15/br_ibge_ipca15__mes_categoria_rm.sql
@@ -10,6 +10,13 @@
         ],
     )
 }}
+
+
+with
+    drop_duplicates as (
+        select distinct *
+        from `basedosdados-staging.br_ibge_ipca15_staging.mes_categoria_rm`
+    )
 select
     safe_cast(ano as int64) ano,
     safe_cast(mes as int64) mes,
@@ -21,7 +28,7 @@ select
     safe_cast(variacao_mensal as float64) variacao_mensal,
     safe_cast(variacao_anual as float64) variacao_anual,
     safe_cast(variacao_doze_meses as float64) variacao_doze_meses
-from `basedosdados-staging.br_ibge_ipca15_staging.mes_categoria_rm` as t
+from drop_duplicates as t
 {% if is_incremental() %}
     where
         date(cast(ano as int64), cast(mes as int64), 1)


### PR DESCRIPTION
Faz fix temporário de valores duplicados em br_ibge_ipca e br_ibge_ipca15

`1. br_ibge_ipca`
- mes_brasil - 2023 10 & 2024 2 duplicados
- mes_categoria_brasil - 2023 10
- mes_categoria_municipio - 2023 10
- mes_categoria_rm - 2023 10

`2. br_ibge_ipca15`
- mes_brasil - sem duplicatas (por precaução retirei)
- mes_categoria_brasil - 2023 10
- mes_categoria_municipio - 2023 10
- mes_categoria_rm - 2023 10