### PR TITLE
[dbt] br_bd_diretorios_brasil & br_ms_cnes

### DIFF
--- a/models/br_bd_diretorios_brasil/br_bd_diretorios_brasil__cbo_1994.sql
+++ b/models/br_bd_diretorios_brasil/br_bd_diretorios_brasil__cbo_1994.sql
@@ -1,0 +1,12 @@
+{{
+    config(
+        alias="cbo_1994",
+        schema="br_bd_diretorios_brasil",
+        materialized="table",
+    )
+}}
+
+select
+    safe_cast(cbo_1994 as string) cbo_1994,
+    safe_cast(initcap(descricao) as string) descricao
+from `basedosdados-staging.br_bd_diretorios_brasil_staging.cbo_1994` as t

--- a/models/br_bd_diretorios_brasil/br_bd_diretorios_brasil__cbo_2002.sql
+++ b/models/br_bd_diretorios_brasil/br_bd_diretorios_brasil__cbo_2002.sql
@@ -19,5 +19,6 @@ select
         initcap(descricao_subgrupo_principal) as string
     ) descricao_subgrupo_principal,
     safe_cast(grande_grupo as string) grande_grupo,
-    safe_cast(initcap(descricao_grande_grupo) as string) descricao_grande_grupo
+    safe_cast(initcap(descricao_grande_grupo) as string) descricao_grande_grupo,
+    safe_cast(indicador_cbo_2002_ativa as int64) indicador_cbo_2002_ativa
 from `basedosdados-staging.br_bd_diretorios_brasil_staging.cbo_2002` as t

--- a/models/br_bd_diretorios_brasil/br_bd_diretorios_brasil__cbo_2002.sql
+++ b/models/br_bd_diretorios_brasil/br_bd_diretorios_brasil__cbo_2002.sql
@@ -9,7 +9,7 @@
 
 select
     safe_cast(cbo_2002 as string) cbo_2002,
-    safe_cast(descricao as string) descricao,
+    safe_cast(initcap(descricao) as string) descricao,
     safe_cast(familia as string) familia,
     safe_cast(descricao_familia as string) descricao_familia,
     safe_cast(subgrupo as string) subgrupo,

--- a/models/br_bd_diretorios_brasil/schema.yml
+++ b/models/br_bd_diretorios_brasil/schema.yml
@@ -24,6 +24,9 @@ models:
         description: Grande Grupo
       - name: descricao_grande_grupo
         description: Descrição do Grande Grupo
+      - name: indicador_cbo_2002_ativa
+        description: Indica se o código de 6 dígitos da CBO de 2002 permanece ativo
+          ou não
   - name: br_bd_diretorios_brasil__empresa
     description: A tabela apresenta informações do Cadastro Nacional da Pessoa Jurídica
       (CNPJ), que é um banco de dados administrado pela Secretaria Especial da Receita

--- a/models/br_ibge_censo_2022/schema.yml
+++ b/models/br_ibge_censo_2022/schema.yml
@@ -920,10 +920,11 @@ models:
       - name: valor
         description: Valor
   - name: br_ibge_censo_2022__quilombolas_localizacao_domicilio_grupo_idade_municipio
-    description: Tabela 8176 - População quilombola, por localização do domicílio, grupos de idade e sexo
+    description: Tabela 8176 - População quilombola, por localização do domicílio,
+      grupos de idade e sexo
     tests:
       - not_null_proportion_multiple_columns:
-            at_least: 0.05
+          at_least: 0.05
     columns:
       - name: ano
         description: Ano
@@ -931,8 +932,8 @@ models:
         description: ID Município IBGE 7 dígitos
         tests:
           - relationships:
-                to: ref('br_bd_diretorios_brasil__municipio')
-                field: id_municipio
+              to: ref('br_bd_diretorios_brasil__municipio')
+              field: id_municipio
       - name: localizacao_domicilio
         description: Localização do Domicílio
       - name: idade_anos
@@ -941,7 +942,7 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               max_value: 120
-              where: 'idade_anos is not null'
+              where: idade_anos is not null
       - name: grupo_idade
         description: Grupo de Idade
       - name: sexo
@@ -949,15 +950,13 @@ models:
       - name: pessoas
         description: Pessoas Quilombolas
   - name: br_ibge_censo_2022__quilombolas_indice_envelhecimento_localizacao_domicilio_municipio
-    description: Tabela 8178 - Índice de envelhecimento, idade mediana e razão de sexo da população quilombola por localização do domicílio.
+    description: Tabela 8178 - Índice de envelhecimento, idade mediana e razão de
+      sexo da população quilombola por localização do domicílio.
     tests:
       - dbt_utils.unique_combination_of_columns:
-            combination_of_columns:
-              - ano
-              - id_municipio
-              - localizacao_domicilio
+          combination_of_columns: [ano, id_municipio, localizacao_domicilio]
       - not_null_proportion_multiple_columns:
-            at_least: 0.05
+          at_least: 0.05
     columns:
       - name: ano
         description: Ano
@@ -965,8 +964,8 @@ models:
         description: ID Município IBGE 7 dígitos
         tests:
           - relationships:
-                to: ref('br_bd_diretorios_brasil__municipio')
-                field: id_municipio
+              to: ref('br_bd_diretorios_brasil__municipio')
+              field: id_municipio
       - name: localizacao_domicilio
         description: Localização do Domicílio
       - name: indice_envelhecimento
@@ -977,18 +976,19 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               max_value: 120
-              where: 'idade_mediana is not null'
+              where: idade_mediana is not null
       - name: razao_sexo
         description: Razão de sexo da população quilombola
         tests:
           - dbt_utils.expression_is_true:
               expression: '>= 1'
-              where: 'razao_sexo is not null'
+              where: razao_sexo is not null
   - name: br_ibge_censo_2022__quilombolas_populacao_residente_grupo_idade_territorio_quilombola
-    description: Tabela 9765 - População residente em territórios quilombolas, total e quilombola, por grupos de idade e sexo, segundo os Territórios Quilombolas
+    description: Tabela 9765 - População residente em territórios quilombolas, total
+      e quilombola, por grupos de idade e sexo, segundo os Territórios Quilombolas
     tests:
       - not_null_proportion_multiple_columns:
-            at_least: 0.05
+          at_least: 0.05
     columns:
       - name: ano
         description: Ano
@@ -998,8 +998,8 @@ models:
         description: Sigla da Unidade da Federação
         tests:
           - relationships:
-                to: ref('br_bd_diretorios_brasil__uf')
-                field: sigla
+              to: ref('br_bd_diretorios_brasil__uf')
+              field: sigla
       - name: sexo
         description: Sexo
       - name: idade_anos
@@ -1008,7 +1008,7 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               max_value: 120
-              where: 'idade_anos is not null'
+              where: idade_anos is not null
       - name: grupo_idade
         description: Grupo de Idade
       - name: pessoas_quilombolas
@@ -1016,14 +1016,14 @@ models:
       - name: populacao_residente
         description: Pessoas residentes em territórios quilombolas
   - name: br_ibge_censo_2022__quilombolas_indice_envelhecimento_territorio_quilombola
-    description: Tabela 9767 - Índice de envelhecimento, idade mediana e razão de sexo da população residente em territórios quilombolas, total e quilombola, segundo os Territórios Quilombolas
+    description: Tabela 9767 - Índice de envelhecimento, idade mediana e razão de
+      sexo da população residente em territórios quilombolas, total e quilombola,
+      segundo os Territórios Quilombolas
     tests:
       - dbt_utils.unique_combination_of_columns:
-            combination_of_columns:
-              - ano
-              - id_territorio_quilombola
+          combination_of_columns: [ano, id_territorio_quilombola]
       - not_null_proportion_multiple_columns:
-            at_least: 0.05
+          at_least: 0.05
     columns:
       - name: ano
         description: Ano
@@ -1035,38 +1035,39 @@ models:
         description: Sigla da Unidade da Federação
         tests:
           - relationships:
-                to: ref('br_bd_diretorios_brasil__uf')
-                field: sigla
+              to: ref('br_bd_diretorios_brasil__uf')
+              field: sigla
       - name: indice_envelhecimento
         description: Índice de envelhecimento da população residente em territórios
-            quilombolas
+          quilombolas
       - name: idade_mediana
         description: Idade mediana da população residente em territórios quilombolas
         tests:
           - dbt_utils.accepted_range:
               min_value: 0
               max_value: 120
-              where: 'idade_mediana is not null'
+              where: idade_mediana is not null
       - name: razao_sexo
         description: Razão de sexo da população residente em territórios quilombolas
         tests:
           - dbt_utils.expression_is_true:
               expression: '>= 1'
-              where: 'razao_sexo is not null'
+              where: razao_sexo is not null
       - name: indice_envelhecimento_populacao_quilombola
         description: Índice de envelhecimento da população quilombola residente em
-            territórios quilombolas
+          territórios quilombolas
       - name: idade_mediana_populacao_quilombola
         description: Idade mediana da população quilombola residente em territórios
-            quilombolas
+          quilombolas
       - name: razao_sexo_quilombola
         description: Razão de sexo da população quilombola residente em territórios
-            quilombolas
+          quilombolas
   - name: br_ibge_censo_2022__indigenas_localizacao_docimicilio_grupo_idade_municipio
-    description: Tabela 8175 - População indígena, por localização do domicílio, grupos de idade e sexo
+    description: Tabela 8175 - População indígena, por localização do domicílio, grupos
+      de idade e sexo
     tests:
       - not_null_proportion_multiple_columns:
-            at_least: 0.05
+          at_least: 0.05
     columns:
       - name: ano
         description: Ano
@@ -1074,8 +1075,8 @@ models:
         description: ID Município IBGE 7 dígitos
         tests:
           - relationships:
-                to: ref('br_bd_diretorios_brasil__municipio')
-                field: id
+              to: ref('br_bd_diretorios_brasil__municipio')
+              field: id
       - name: localizacao_domicilio
         description: Localização do Domicílio
       - name: idade_anos
@@ -1087,16 +1088,17 @@ models:
       - name: pessoas
         description: Pessoas Indígenas
   - name: br_ibge_censo_2022__indigenas_indice_envelhecimento_localizacao_domicilio_municipio
-    description: Tabela 8177 - Índice de envelhecimento, idade mediana e razão de sexo da população indígena, segundo localização do domicílio e quesito de declaração
+    description: Tabela 8177 - Índice de envelhecimento, idade mediana e razão de
+      sexo da população indígena, segundo localização do domicílio e quesito de declaração
     tests:
       - dbt_utils.unique_combination_of_columns:
-            combination_of_columns:
-              - ano
-              - id_municipio
-              - localizacao_domicilio
-              - quesito_declaracao_indigena
+          combination_of_columns:
+            - ano
+            - id_municipio
+            - localizacao_domicilio
+            - quesito_declaracao_indigena
       - not_null_proportion_multiple_columns:
-            at_least: 0.05
+          at_least: 0.05
     columns:
       - name: ano
         description: Ano
@@ -1104,8 +1106,8 @@ models:
         description: ID Município IBGE 7 dígitos
         tests:
           - relationships:
-                to: ref('br_bd_diretorios_brasil__municipio')
-                field: id_municipio
+              to: ref('br_bd_diretorios_brasil__municipio')
+              field: id_municipio
       - name: localizacao_domicilio
         description: Localização do Domicílio
       - name: quesito_declaracao_indigena
@@ -1118,25 +1120,27 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               max_value: 120
-              where: 'idade_mediana is not null'
+              where: idade_mediana is not null
       - name: razao_sexo
         description: Razão de sexo da população indígena
         tests:
           - dbt_utils.expression_is_true:
               expression: '>= 1'
-              where: 'razao_sexo is not null'
+              where: razao_sexo is not null
   - name: br_ibge_censo_2022__indigenas_populacao_residente_grupo_idade_terras_indigenas
-    description: Tabela 9764 - População residente em terras indígenas, total e indígenas, por grupos de idade, sexo e quesito de declaração indígena, segundo as Terras Indígenas
+    description: Tabela 9764 - População residente em terras indígenas, total e indígenas,
+      por grupos de idade, sexo e quesito de declaração indígena, segundo as Terras
+      Indígenas
     tests:
       - dbt_utils.unique_combination_of_columns:
-            combination_of_columns:
-              - id_terra_indigena
-              - quesito_declaracao_indigena
-              - sexo
-              - idade_anos
-              - ano
+          combination_of_columns:
+            - id_terra_indigena
+            - quesito_declaracao_indigena
+            - sexo
+            - idade_anos
+            - ano
       - not_null_proportion_multiple_columns:
-            at_least: 0.05
+          at_least: 0.05
     columns:
       - name: id_terra_indigena
         description: ID da Terra Indígena
@@ -1146,8 +1150,8 @@ models:
         description: Sigla da Unidade da Federação
         tests:
           - relationships:
-                to: ref('br_bd_diretorios_brasil__uf')
-                field: sigla
+              to: ref('br_bd_diretorios_brasil__uf')
+              field: sigla
       - name: quesito_declaracao_indigena
         description: Quesito declaração indígena
       - name: sexo
@@ -1161,17 +1165,19 @@ models:
       - name: populacao_residente
         description: Pessoas residentes em terras indígenas
   - name: br_ibge_censo_2022__indigenas_indice_envelhecimento_terras_indigenas
-    description: Tabela 9766 - Índice de envelhecimento, idade mediana e razão de sexo da população residente em terras indígenas, total e indígenas, segundo quesito de declaração e as Terras Indígenas
+    description: Tabela 9766 - Índice de envelhecimento, idade mediana e razão de
+      sexo da população residente em terras indígenas, total e indígenas, segundo
+      quesito de declaração e as Terras Indígenas
     tests:
       - dbt_utils.unique_combination_of_columns:
-            combination_of_columns:
-              - ano
-              - id_terra_indigena
-              - terra_indigena
-              - sigla_uf
-              - quesito_declaracao_indigena
+          combination_of_columns:
+            - ano
+            - id_terra_indigena
+            - terra_indigena
+            - sigla_uf
+            - quesito_declaracao_indigena
       - not_null_proportion_multiple_columns:
-            at_least: 0.05
+          at_least: 0.05
     columns:
       - name: ano
         description: Ano
@@ -1183,8 +1189,8 @@ models:
         description: Sigla da Unidade da Federação
         tests:
           - relationships:
-                to: ref('br_bd_diretorios_brasil__uf')
-                field: sigla
+              to: ref('br_bd_diretorios_brasil__uf')
+              field: sigla
       - name: quesito_declaracao_indigena
         description: Quesito declaração indígena
       - name: indice_envelhecimento
@@ -1195,16 +1201,16 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               max_value: 120
-              where: 'idade_mediana is not null'
+              where: idade_mediana is not null
       - name: razao_sexo
         description: Razão de sexo da população residente em terras indígenas
         tests:
           - dbt_utils.expression_is_true:
               expression: '>= 1'
-              where: 'razao_sexo is not null'
+              where: razao_sexo is not null
       - name: indice_envelhecimento_populacao_indigena
         description: Índice de envelhecimento da população indígena residente em terras
-            indígenas
+          indígenas
       - name: idade_mediana_populacao_indigena
         description: Idade mediana da população indígena residente em terras indígenas
       - name: razao_sexo_populacao_indigena

--- a/models/br_ms_cnes/br_ms_cnes__dicionario.sql
+++ b/models/br_ms_cnes/br_ms_cnes__dicionario.sql
@@ -1,4 +1,6 @@
 {{ config(alias="dicionario", schema="br_ms_cnes") }}
+
+
 select
     safe_cast(id_tabela as string) id_tabela,
     safe_cast(nome_coluna as string) nome_coluna,


### PR DESCRIPTION
- `Leva novo dicionário do CNES p/ prod;`
------------------------

`- Insere códigos cbo_2002 atualmente desativados para permitir o cruzamento com a tabela `profissional ` do conjunto `br_ms_cnes``
`- Insere coluna indicador_cbo_2002_ativa que indetifica se o código de 6 dígitos da cbo_2002 permanece ativo ou não
`
Contexto:
- Existem 394 valores distribuidos por 100 milhões de linham que não tem conexão com diretório de CBO. 
1. CBO na tabela de definição do CNES: 223109 é um dos valores que falham no teste. 
![Pasted image 20240510082918](https://github.com/basedosdados/queries-basedosdados/assets/61624649/1f6318cd-b3d8-4c46-8034-d1fc75ed045c)

2. CBO no diretório da BD: Na BD só esta presente o valor atual;
 ![Pasted image 20240510082941](https://github.com/basedosdados/queries-basedosdados/assets/61624649/613554d3-0ff6-4e2d-a965-cf098257e2f1)

3. CBO no site do MTE: indica que  a família antiga foi desativada;
![Pasted image 20240510083047](https://github.com/basedosdados/queries-basedosdados/assets/61624649/a365058b-0e5c-4e9a-8b47-b906068d78e7)



