### PR TITLE
fix: tipo_eleicao in 2004

### DIFF
--- a/models/br_tse_eleicoes/br_tse_eleicoes__resultados_candidato.sql
+++ b/models/br_tse_eleicoes/br_tse_eleicoes__resultados_candidato.sql
@@ -10,7 +10,7 @@
         },
     )
 }}
-select 
+select
     safe_cast(ano as int64) ano,
     safe_cast(turno as int64) turno,
     safe_cast(tipo_eleicao as string) tipo_eleicao,

--- a/models/br_tse_eleicoes/br_tse_eleicoes__resultados_candidato_municipio.sql
+++ b/models/br_tse_eleicoes/br_tse_eleicoes__resultados_candidato_municipio.sql
@@ -11,7 +11,7 @@
         cluster_by=["sigla_uf"],
     )
 }}
-select 
+select
     safe_cast(ano as int64) ano,
     safe_cast(turno as int64) turno,
     safe_cast(tipo_eleicao as string) tipo_eleicao,

--- a/models/br_tse_eleicoes/br_tse_eleicoes__resultados_candidato_municipio_zona.sql
+++ b/models/br_tse_eleicoes/br_tse_eleicoes__resultados_candidato_municipio_zona.sql
@@ -11,7 +11,7 @@
         cluster_by=["sigla_uf"],
     )
 }}
-select 
+select
     safe_cast(ano as int64) ano,
     safe_cast(turno as int64) turno,
     safe_cast(tipo_eleicao as string) tipo_eleicao,

--- a/models/br_tse_eleicoes/br_tse_eleicoes__resultados_partido_municipio.sql
+++ b/models/br_tse_eleicoes/br_tse_eleicoes__resultados_partido_municipio.sql
@@ -11,7 +11,7 @@
         cluster_by=["sigla_uf"],
     )
 }}
-select
+select 
     safe_cast(ano as int64) ano,
     safe_cast(turno as int64) turno,
     safe_cast(tipo_eleicao as string) tipo_eleicao,

--- a/models/br_tse_eleicoes/br_tse_eleicoes__resultados_partido_municipio_zona.sql
+++ b/models/br_tse_eleicoes/br_tse_eleicoes__resultados_partido_municipio_zona.sql
@@ -11,7 +11,7 @@
         cluster_by=["sigla_uf"],
     )
 }}
-select
+select 
     safe_cast(ano as int64) ano,
     safe_cast(turno as int64) turno,
     safe_cast(tipo_eleicao as string) tipo_eleicao,


### PR DESCRIPTION
Para algumas tabelas estava `tipo_eleicao = eleicoes municipais de 2004 - 1º turno`.