### PR TITLE
[fix] br_rf_cno

### DIFF
--- a/models/br_rf_cno/br_rf_cno__microdados.sql
+++ b/models/br_rf_cno/br_rf_cno__microdados.sql
@@ -7,7 +7,6 @@
             "field": "data_extracao",
             "data_type": "date",
         },
-        pre_hook="DROP ALL ROW ACCESS POLICIES ON {{ this }}",
     )
 }}
 

--- a/models/br_rf_cno/br_rf_cno__vinculos.sql
+++ b/models/br_rf_cno/br_rf_cno__vinculos.sql
@@ -7,7 +7,6 @@
             "field": "data_extracao",
             "data_type": "date",
         },
-        pre_hook="DROP ALL ROW ACCESS POLICIES ON {{ this }}",
     )
 }}
 


### PR DESCRIPTION
- Remove pre hook dos modelos vinculos e microdados
- Como as tabelas ainda não estão materializadas o pre hook crasha.