### PR TITLE
[dados] br_tse_eleicoes: bens_candidato|candidatos

### DIFF
--- a/models/br_tse_eleicoes/br_tse_eleicoes__bens_candidato.sql
+++ b/models/br_tse_eleicoes/br_tse_eleicoes__bens_candidato.sql
@@ -6,7 +6,7 @@
         partition_by={
             "field": "ano",
             "data_type": "int64",
-            "range": {"start": 2006, "end": 2022, "interval": 2},
+            "range": {"start": 2006, "end": 2024, "interval": 2},
         },
     )
 }}
@@ -16,7 +16,7 @@ select
     safe_cast(sigla_uf as string) sigla_uf,
     safe_cast(id_eleicao as string) id_eleicao,
     safe_cast(tipo_eleicao as string) tipo_eleicao,
-    safe_cast(data_eleicao as string) data_eleicao,
+    safe_cast(data_eleicao as date) data_eleicao,
     safe_cast(sequencial_candidato as string) sequencial_candidato,
     safe_cast(id_candidato_bd as string) id_candidato_bd,
     safe_cast(id_tipo_item as string) id_tipo_item,

--- a/models/br_tse_eleicoes/br_tse_eleicoes__candidatos.sql
+++ b/models/br_tse_eleicoes/br_tse_eleicoes__candidatos.sql
@@ -6,7 +6,7 @@
         partition_by={
             "field": "ano",
             "data_type": "int64",
-            "range": {"start": 1994, "end": 2022, "interval": 2},
+            "range": {"start": 1994, "end": 2024, "interval": 2},
         },
     )
 }}
@@ -15,7 +15,7 @@ select
     safe_cast(ano as int64) ano,
     safe_cast(id_eleicao as string) id_eleicao,
     safe_cast(tipo_eleicao as string) tipo_eleicao,
-    safe_cast(data_eleicao as string) data_eleicao,
+    safe_cast(data_eleicao as date) data_eleicao,
     safe_cast(sigla_uf as string) sigla_uf,
     safe_cast(id_municipio as string) id_municipio,
     safe_cast(id_municipio_tse as string) id_municipio_tse,

--- a/models/br_tse_eleicoes/schema.yml
+++ b/models/br_tse_eleicoes/schema.yml
@@ -5,7 +5,7 @@ models:
     description: Declaração de bens de candidatos em eleições brasileiras.
     tests:
       - not_null_proportion_multiple_columns:
-          at_least: 0.95
+          at_least: 0.55
     columns:
       - name: ano
         description: Ano
@@ -15,6 +15,10 @@ models:
               field: ano.ano
       - name: data_eleicao
         description: Data da eleição
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__data')
+              field: data.data
       - name: descricao_item
         description: Descrição do item
       - name: id_candidato_bd
@@ -40,6 +44,8 @@ models:
   - name: br_tse_eleicoes__candidatos
     description: Dados de candidatos em eleições brasileiras.
     tests:
+      - not_null_proportion_multiple_columns:
+          at_least: 0.05
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - ano
@@ -63,12 +69,28 @@ models:
         description: CPF
       - name: data_eleicao
         description: Data da eleição
-      - name: data_nascimento
-        description: Data de nascimento
         tests:
           - relationships:
               to: ref('br_bd_diretorios_data_tempo__data')
               field: data.data
+      - name: data_nascimento
+        description: Data de nascimento
+        tests:
+          - custom_relationships:
+              to: ref('br_bd_diretorios_data_tempo__data')
+              field: data.data
+              ignore_values:
+                - '9564-06-17'
+                - '5195-06-20'
+                - '9555-01-15'
+                - '6196-10-02'
+                - '7194-10-30'
+                - '5454-10-09'
+                - '6197-10-02'
+                - '9158-09-24'
+                - '7197-04-17'
+                - '9161-11-09'
+                - '7953-09-05'
       - name: email
         description: Email
       - name: estado_civil
@@ -90,9 +112,10 @@ models:
       - name: id_municipio_tse
         description: ID Município - TSE
         tests:
-          - relationships:
+          - custom_relationships:
               to: ref('br_bd_diretorios_brasil__municipio')
               field: id_municipio_tse
+              ignore_values: ['73709']
       - name: instrucao
         description: Instrução
       - name: municipio_nascimento


### PR DESCRIPTION

*Atualizando dataset br_tse_eleicoes, tabelas bens_candidato e candidatos com o ano de 2024*

# br_tse_eleicoes

Tabela|Linhas|Materialização |sources|
|:-:|:-:|:-:|:-:|
candidatos|3346377|949.83 MB|[:link:][candidatos]
bens_candidato |4954328|642.6 MB|[:link:][bens]

## candidatos

**Atualmente tanto os dados de 2022 e 2024 dos canditados. Vem com a necessidade de serém completados com dados [complementares][complementar] de um arquivo csv separado do arqueivo original dos canditatos.**

Os dados se ligam ao complementares pela coluna `SQ_CANDIDATO`

- Coluna `data_eleicao` foi colocada como `DATE` anteriormente estava como string quebrando o test de relacionamento com `br_bd_diretorios_data_tempo__data`
- Coluna `id_municipio` temos 53 casos em 2024 onde ela se encontra vazia. Ocorrência devido a um novo `id_municipio_tse` representado por `73709`. Isso também justifica o valor está sendo ignorado no teste de relacionamento com `br_bd_diretorios_brasil__municipio`
- Coluna `cpf` infelizmente está totalmente vazia em 2024, fonte original não divulgando, mais informaçoes no `leiame.pdf` entre os arquivos em [candidatos][candidatos].
> **_NOTE:_** Os endereços informados para atribuição de CNPJ, comunicações processuais e do Comitê Central de
Campanha, telefone pessoal, e-mail pessoal, número do CPF e o documento pessoal de identificação não serão
divulgados no DivulgaCandContas e serão juntados como documento sigiloso no processo de registro de
candidatura no PJe. (incluído pela Resolução nº 23.729/2024)”
Portanto, são considerados como não divulgáveis, para as Eleições 2024, as informações registradas na variável
NR_CPF_CANDIDATO dos arquivos de candidaturas do Portal de Dados Abertos..
- Coluna `data_nascimento` foi colocado o teste de relacionamento com `'br_bd_diretorios_data_tempo__data'`, encontramos 11 ocorrências de datas estranhas que não passam no teste e já se encontram em produção. Elas ficaram como valores a serem ignorados pelo teste. Ano de 2024 foi usado uma margem que pessoas com menos de 18 anos e maior de 120 anos tem suas datas anuladas.


## bens_candidato 

- Coluna `data_eleicao` foi colocada como `DATE` anteriormente estava como string quebrando o test de relacionamento com `br_bd_diretorios_data_tempo__data`
-  Teste ` not_null_proportion_multiple_columns` foi reduzido para `0.55` devido algumas colunas já em produção terem apenas  62% de preenchimento. Exemplo: `tipo_item`, `id_tipo_item`, `data_eleicao` e `id_eleicao `
  
[candidatos]: https://dadosabertos.tse.jus.br/dataset/candidatos-2024/resource/af76c401-0972-4ddf-8ea8-00e310ae53b4
[complementar]: https://dadosabertos.tse.jus.br/dataset/candidatos-2024/resource/7a9e61af-2425-4f7a-acf2-19338e82d12c
[bens]: https://dadosabertos.tse.jus.br/dataset/candidatos-2024/resource/2d078979-116f-498f-ac5b-2e2a6fb0ff1f
