### PR TITLE
[dados] br_tse_eleicoes: despesas_candidato|receitas_candidato

### DIFF
--- a/models/br_tse_eleicoes/br_tse_eleicoes__despesas_candidato.sql
+++ b/models/br_tse_eleicoes/br_tse_eleicoes__despesas_candidato.sql
@@ -6,7 +6,7 @@
         partition_by={
             "field": "ano",
             "data_type": "int64",
-            "range": {"start": 2002, "end": 2022, "interval": 2},
+            "range": {"start": 2002, "end": 2024, "interval": 2},
         },
     )
 }}
@@ -16,7 +16,7 @@ select
     safe_cast(turno as int64) turno,
     safe_cast(id_eleicao as string) id_eleicao,
     safe_cast(tipo_eleicao as string) tipo_eleicao,
-    safe_cast(data_eleicao as string) data_eleicao,
+    safe_cast(data_eleicao as date) data_eleicao,
     safe_cast(sigla_uf as string) sigla_uf,
     safe_cast(id_municipio as string) id_municipio,
     safe_cast(id_municipio_tse as string) id_municipio_tse,

--- a/models/br_tse_eleicoes/br_tse_eleicoes__receitas_candidato.sql
+++ b/models/br_tse_eleicoes/br_tse_eleicoes__receitas_candidato.sql
@@ -6,7 +6,7 @@
         partition_by={
             "field": "ano",
             "data_type": "int64",
-            "range": {"start": 2002, "end": 2022, "interval": 2},
+            "range": {"start": 2002, "end": 2024, "interval": 2},
         },
     )
 }}
@@ -15,7 +15,7 @@ select
     safe_cast(turno as int64) turno,
     safe_cast(id_eleicao as string) id_eleicao,
     safe_cast(tipo_eleicao as string) tipo_eleicao,
-    safe_cast(data_eleicao as string) data_eleicao,
+    safe_cast(data_eleicao as date) data_eleicao,
     safe_cast(sigla_uf as string) sigla_uf,
     safe_cast(id_municipio as string) id_municipio,
     safe_cast(id_municipio_tse as string) id_municipio_tse,
@@ -66,7 +66,7 @@ select
     safe_cast(numero_recibo_doacao as string) numero_recibo_doacao,
     safe_cast(numero_documento_doacao as string) numero_documento_doacao,
     safe_cast(tipo_prestacao_contas as string) tipo_prestacao_contas,
-    safe_cast(data_prestacao_contas as string) data_prestacao_contas,
+    safe_cast(data_prestacao_contas as date) data_prestacao_contas,
     safe_cast(sequencial_prestador_contas as string) sequencial_prestador_contas,
     safe_cast(cnpj_prestador_contas as string) cnpj_prestador_contas,
     safe_cast(entrega_conjunto as string) entrega_conjunto

--- a/models/br_tse_eleicoes/schema.yml
+++ b/models/br_tse_eleicoes/schema.yml
@@ -154,9 +154,6 @@ models:
         description: Título eleitoral
   - name: br_tse_eleicoes__despesas_candidato
     description: Dados de despesas em campanhas eleitorais a nível de despesa.
-    tests:
-      - not_null_proportion_multiple_columns:
-          at_least: 0.95
     columns:
       - name: ano
         description: Ano
@@ -170,10 +167,6 @@ models:
         description: Cargo do fornecedor
       - name: cnae_2_fornecedor
         description: Classificação Nacional de Atividades Econômicas 2.0 do fornecedor
-        tests:
-          - relationships:
-              to: ref('br_bd_diretorios_brasil__cnae_2')
-              field: cnae_2.cnae_2
       - name: cnpj_candidato
         description: CNPJ do candidato
       - name: cnpj_prestador_contas
@@ -188,8 +181,16 @@ models:
         description: Data da despesa
       - name: data_eleicao
         description: Data da eleição
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__data')
+              field: data.data
       - name: data_prestacao_contas
         description: Data de prestação de contas
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__data')
+              field: data.data
       - name: descricao_cnae_2_fornecedor
         description: Descrição da Classificação Nacional de Atividades Econômicas
           2.0 do fornecedor
@@ -207,10 +208,24 @@ models:
         description: ID Eleição
       - name: id_municipio
         description: ID Município - IBGE 7 Dígitos
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_brasil__municipio')
+              field: id_municipio
       - name: id_municipio_tse
         description: ID Município - TSE
+        tests:
+          - custom_relationships:
+              to: ref('br_bd_diretorios_brasil__municipio')
+              field: id_municipio_tse
+              ignore_values: ['73709']
       - name: id_municipio_tse_fornecedor
         description: ID Município do fornecedor - TSE
+        tests:
+          - custom_relationships:
+              to: ref('br_bd_diretorios_brasil__municipio')
+              field: id_municipio_tse
+              ignore_values: ['73709']
       - name: nome_candidato
         description: Nome do candidato
       - name: nome_fornecedor
@@ -247,8 +262,17 @@ models:
         description: Sigla do partido do fornecedor
       - name: sigla_uf
         description: Sigla da unidade da federação
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_brasil__uf')
+              field: sigla
       - name: sigla_uf_fornecedor
         description: Sigla da unidade da federação do fornecedor
+        tests:
+          - custom_relationships:
+              to: ref('br_bd_diretorios_brasil__uf')
+              field: sigla
+              ignore_values: [BR]
       - name: tipo_despesa
         description: Tipo da despesa
       - name: tipo_documento
@@ -686,9 +710,6 @@ models:
         description: Zona eleitoral
   - name: br_tse_eleicoes__receitas_candidato
     description: Dados de financiamento de campanha de receita para candidatos.
-    tests:
-      - not_null_proportion_multiple_columns:
-          at_least: 0.95
     columns:
       - name: ano
         description: Ano
@@ -702,10 +723,6 @@ models:
         description: Cargo do candidato doador
       - name: cnae_2_doador
         description: Classificação Nacional de Atividades Econômicas 2.0 do doador
-        tests:
-          - relationships:
-              to: ref('br_bd_diretorios_brasil__cnae_2')
-              field: cnae_2.cnae_2
       - name: cnpj_candidato
         description: CNPJ do candidato
       - name: cnpj_prestador_contas
@@ -722,14 +739,18 @@ models:
         description: CPF do vice ou suplente
       - name: data_eleicao
         description: Data da eleição
-      - name: data_prestacao_contas
-        description: Data de prestação de contas
-      - name: data_receita
-        description: Data da receita
         tests:
           - relationships:
               to: ref('br_bd_diretorios_data_tempo__data')
               field: data.data
+      - name: data_prestacao_contas
+        description: Data de prestação de contas
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__data')
+              field: data.data
+      - name: data_receita
+        description: Data da receita
       - name: descricao_cnae_2_doador
         description: Descrição da Classificação Nacional de Atividades Econômicas
           2.0 do doador
@@ -752,10 +773,24 @@ models:
         description: ID Eleição
       - name: id_municipio
         description: ID Município - IBGE 7 Dígitos
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_brasil__municipio')
+              field: id_municipio
       - name: id_municipio_tse
         description: ID Município - TSE
+        tests:
+          - custom_relationships:
+              to: ref('br_bd_diretorios_brasil__municipio')
+              field: id_municipio_tse
+              ignore_values: ['73709']
       - name: id_municipio_tse_doador
         description: ID Município do doador - TSE
+        tests:
+          - custom_relationships:
+              to: ref('br_bd_diretorios_brasil__municipio')
+              field: id_municipio_tse
+              ignore_values: ['73709']
       - name: natureza_receita
         description: Natureza da receita
       - name: nome_administrador
@@ -806,6 +841,10 @@ models:
         description: Sigla do partido do doador
       - name: sigla_uf
         description: Sigla da unidade da federação
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_brasil__uf')
+              field: sigla
       - name: sigla_uf_doador
         description: Sigla da unidade da federação do doador
       - name: situacao_receita


### PR DESCRIPTION
*Atualizando dataset br_tse_eleicoes, tabelas despesas_candidato e receitas_candidato com o ano de 2024*

# br_tse_eleicoes

Tabela|Linhas|Materialização |sources|
|:-:|:-:|:-:|:-:|
receitas_candidato|13401642|862.4 MiB|[:link:][source]
despesas_candidato|28226542|12.45 GB|[:link:][source]

## despesas_candidato

- [x] `esfera_partidaria_fornecedor` coluna totalmente vazia e em produção.
```sql
SELECT * FROM `basedosdados.br_tse_eleicoes.despesas_candidato` where esfera_partidaria_fornecedor is not null
```
- [x] Coluna `cnae_2_fornecedor` tem 545 valores que não batem com o diretorio do `cnae_2.subclasse`
- [x] 2022 atualmente tem 2007 linhas mais do que os dados em produção
- [x] Coluna `data_despesa` tem 81 datas com valores invalidos
```sql
select distinct data_despesa
from `basedosdados`.`br_tse_eleicoes`.`despesas_candidato`
where data_despesa >= current_date()
``` 
- [x] coluna `esfera_partidaria_fornecedor` tem menos de 1% de valores preenchidos. invalidados o test de null. Existe outras colunas com valores baixos também


## receitas_candidato

- [x] coluna `data_receita`  tem 17 datas com valores bem absurdos
- [x] coluna `sigla_uf_doador` diversos valores que não batem com siglas ufs.
```sql
select distinct sigla_uf_doador as from_field
from `basedosdados`.`br_tse_eleicoes`.`receitas_candidato`
where sigla_uf_doador is not null
```
- [x] coluna `cnae_2_doador` tem 87 valores que não batem com o diretorio do `cnae_2.subclasse`
- [x] coluna `descricao_cnae_2_doador_orig` tem menos de 1% de valores preenchidos. invalidados o test de null. Existe outras colunas com valores baixos também

  
[source]: https://dadosabertos.tse.jus.br/dataset/prestacao-de-contas-eleitorais-2024/resource/c74840a4-f303-4771-af44-ecbf15bfc302