### PR TITLE
[fix]br_ibge_pnadc.microdados

### DIFF
--- a/models/br_ibge_pnadc/schema.yml
+++ b/models/br_ibge_pnadc/schema.yml
@@ -3,17 +3,40 @@ version: 2
 models:
   - name: br_ibge_pnadc__microdados
     description: Microdados PNADC
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [ano, trimestre, id_pessoa]
     columns:
       - name: ano
         description: Ano
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__ano')
+              field: ano.ano
       - name: trimestre
         description: Trimestre
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__trimestre')
+              field: trimestre
       - name: id_uf
         description: ID Unidade da Federação
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_brasil__uf')
+              field: id_uf
       - name: sigla_uf
         description: Sigla da Unidade da Federação
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_brasil__uf')
+              field: sigla
       - name: capital
         description: Município da Capital
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_brasil__uf')
+              field: id_uf
       - name: rm_ride
         description: Região Metropolitana e Região Administrativa Integrada
       - name: id_upa


### PR DESCRIPTION
**Adicionando testes para br_ibge_pnadc.microdados**

# br_ibge_pnadc.microdados

> **_NOTE:_* Dados referentes ao momento criado do PR. Tabela focada na situação atual entre os dados de DEV e PROD

Repositório|Linhas|Materialização|Max Data|sources|
|:-:|:-:|:-:|:-:|:-:|
prod|25527730|46.5 GB|2024-03-01|[:link:][source]
dev|26007716|47.37 GB|2024-06-01|[:link:][source]


### Testes
- *not_null_proportion_multiple_columns*:
> **_NOTE:_** Coluna `V405122` tem menos de 1% de dados preenchidos anulando a utilização do teste `not_null_proportion_multiple_columns`.
Existe outra colunas com situação semelhante.
- *unique_combination_of_columns*:
  - ano
  - trimestre
  - id_pessoa
- *Colunas com `relationships`* :
  - ano
  - trimestre
  - id_uf
  - sigla_uf
  - capital

[source]: https://ftp.ibge.gov.br/Trabalho_e_Rendimento/Pesquisa_Nacional_por_Amostra_de_Domicilios_continua/Trimestral/Microdados/2024/