### PR TITLE
[fix] br_bcb_sicor.liberacao

### DIFF
--- a/models/br_bcb_sicor/br_bcb_sicor__microdados_liberacao.sql
+++ b/models/br_bcb_sicor/br_bcb_sicor__microdados_liberacao.sql
@@ -17,7 +17,7 @@ select
     safe_cast(ano as int64) ano,
     safe_cast(mes as int64) mes,
     safe_cast(data_liberacao as date) data_liberacao,
-    safe_cast(id_referencia_bacen as string) id_referencia_bacen,
-    safe_cast(numero_ordem as string) numero_ordem,
-    safe_cast(valor_liberado as float64) valor_liberado
+    safe_cast(valor_liberado as string) id_referencia_bacen,
+    safe_cast(id_referencia_bacen as string) numero_ordem,
+    safe_cast(numero_ordem as float64) valor_liberado
 from `basedosdados-staging.br_bcb_sicor_staging.microdados_liberacao` as t


### PR DESCRIPTION
- Corrige nomeação de variáveis da tabela br_bcb_sicor

- erro reportado pelo usuário

> Oi, Gabriel. Claro!  Estou trabalhando com essa tabela: https://basedosdados.org/dataset/544c9d22-97b7-479a-8eca-94762840b465?table=d8514322-a6d4-4c7e-a4f7-3ec7860510f6 e identifiquei que a variavel id_referencia_bacen que deveria ser o identificador unico da tabela está com os valores incorretos.

![image](https://github.com/user-attachments/assets/f82fb182-51fa-48fb-a999-faf9a8846db4)

