### PR TITLE
[dados]br_jota 2024

### DIFF
--- a/models/br_jota/br_jota__eleicao_perfil_candidato_2024.sql
+++ b/models/br_jota/br_jota__eleicao_perfil_candidato_2024.sql
@@ -1,0 +1,34 @@
+{{
+    config(
+        alias="eleicao_perfil_candidato_2024",
+        schema="br_jota",
+        materialized="table",
+    )
+}}
+
+select
+    sequencial,
+    concat(ano, sequencial) as ano_sequencial_candidato,
+    nome_urna,
+    sigla_partido,
+    initcap(cargo) as cargo,
+    concat(municipio.nome, ' - ', municipio.sigla_uf) as municipio,
+    candidatos.sigla_uf,
+    initcap(genero) as genero,
+    case when raca is null then 'Nao Informado' else initcap(raca) end as raca,
+    idade,
+    case
+        when safe_cast(idade as int64) < 29
+        then "18-29"
+        when safe_cast(idade as int64) < 50
+        then "30-49"
+        when safe_cast(idade as int64) < 70
+        then "50-69"
+        when safe_cast(idade as int64) >= 70
+        then "70-100"
+    end as faixa_etaria
+from `basedosdados.br_tse_eleicoes.candidatos` as candidatos
+left join
+    `basedosdados.br_bd_diretorios_brasil.municipio` as municipio
+    on candidatos.id_municipio = municipio.id_municipio
+where ano = 2024

--- a/models/br_jota/br_jota__eleicao_prestacao_contas_candidato_2024.sql
+++ b/models/br_jota/br_jota__eleicao_prestacao_contas_candidato_2024.sql
@@ -1,0 +1,58 @@
+{{
+    config(
+        alias="eleicao_prestacao_contas_candidato_2024",
+        schema="br_jota",
+        materialized="table",
+    )
+}}
+
+with
+    soma_receitas_candidato as (
+        select
+            sequencial_candidato,
+            sum(
+                case when origem = 'Recursos De Partido Politico' then valor end
+            ) as receita_partido,
+            sum(
+                case when receita_despesa = 'Receita' then valor end
+            ) as valor_receita_total,
+            sum(
+                case when receita_despesa = 'Despesa' then valor end
+            ) as valor_despesa_total,
+            sum(
+                case when categoria = 'Pessoal' then valor end
+            ) as valor_despesa_pessoal,
+            sum(
+                case when categoria = 'Publicidade' then valor end
+            ) as valor_despesa_publicidade,
+            sum(case when categoria = 'Outros' then valor end) as valor_despesa_outros,
+            sum(
+                case when categoria = 'Operacoes' then valor end
+            ) as valor_despesa_operacoes,
+        from
+            `basedosdados-perguntas.br_jota.eleicao_prestacao_contas_candidato_origem_2024`
+        where sequencial_candidato is not null
+        group by 1
+    )
+
+select
+    candidato_info.*,
+    rank() over (partition by cargo order by valor_receita_total desc) as rank_cargo,
+    rank() over (
+        partition by sigla_partido order by valor_receita_total desc
+    ) as rank_partido,
+    rank() over (
+        partition by cargo, municipio order by valor_receita_total desc
+    ) as rank_cargo_municipio,
+    rank() over (
+        partition by sigla_partido, cargo order by valor_receita_total desc
+    ) as rank_cargo_partido,
+    valor_despesa_pessoal / valor_despesa_total as proporcao_despesa_pessoal,
+    valor_despesa_publicidade / valor_despesa_total as proporcao_despesa_publicidade,
+    valor_despesa_outros / valor_despesa_total as proporcao_despesa_outros,
+    valor_despesa_operacoes / valor_despesa_total as proporcao_despesa_operacoes,
+    valores.* except (sequencial_candidato)
+from `basedosdados-perguntas.br_jota.eleicao_perfil_candidato_2024` as candidato_info
+left join
+    soma_receitas_candidato as valores
+    on candidato_info.sequencial = valores.sequencial_candidato

--- a/models/br_jota/br_jota__eleicao_prestacao_contas_candidato_origem_2024.sql
+++ b/models/br_jota/br_jota__eleicao_prestacao_contas_candidato_origem_2024.sql
@@ -1,0 +1,56 @@
+{{
+    config(
+        alias="eleicao_prestacao_contas_candidato_origem_2024",
+        schema="br_jota",
+        materialized="table",
+    )
+}}
+
+with
+    despesa as (
+        select
+            case when cargo = 'Deputado Federal' then 'excluir' end as excluir,
+            data_despesa as data_conta,
+            sequencial_candidato,
+            concat(ano, sequencial_candidato) as ano_sequencial_candidato,
+            'Despesa' as receita_despesa,
+            initcap(origem_despesa) as origem,
+            sum(valor_despesa) as valor,
+            count(1) as n_linhas
+        from `basedosdados.br_tse_eleicoes.despesas_candidato`
+        where ano = 2024
+        group by 1, 2, 3, 4, 5, 6
+        having excluir is null
+    ),
+
+    receita as (
+        select
+            case when cargo = 'Deputado Federal' then 'excluir' end as excluir,
+            data_receita as data_conta,
+            sequencial_candidato,
+            concat(ano, sequencial_candidato) as ano_sequencial_candidato,
+            'Receita' as receita_despesa,
+            initcap(origem_receita) as origem,
+            sum(valor_receita) as valor,
+            count(1) as n_linhas
+        from `basedosdados.br_tse_eleicoes.receitas_candidato`
+        where ano = 2024
+        group by 1, 2, 3, 4, 5, 6
+        having excluir is null
+    ),
+
+    receita_despesa as (
+        select *
+        from despesa
+        union all
+        select *
+        from receita
+    )
+
+select t1.*, t2.categoria
+from receita_despesa as t1
+left join
+    `basedosdados-perguntas.br_jota.eleicao_auxiliar_categoria_origem` as t2
+    on t1.origem = regexp_replace(normalize(t2.origem, nfd), r"\pM", '')
+where data_conta <= current_date()
+order by data_conta

--- a/models/br_jota/br_jota__eleicao_prestacao_contas_partido_2024.sql
+++ b/models/br_jota/br_jota__eleicao_prestacao_contas_partido_2024.sql
@@ -1,0 +1,23 @@
+{{
+    config(
+        alias="eleicao_prestacao_contas_partido_2024",
+        schema="br_jota",
+        materialized="table",
+    )
+}}
+
+select
+    municipio,
+    sigla_partido,
+    cargo,
+    genero,
+    raca,
+    faixa_etaria,
+    sum(valor_receita_total) as valor_receita_total,
+    sum(valor_despesa_total) as valor_despesa_total,
+    sum(valor_despesa_pessoal) as valor_despesa_pessoal,
+    sum(valor_despesa_publicidade) as valor_despesa_publicidade,
+    sum(valor_despesa_outros) as valor_despesa_outros,
+    sum(valor_despesa_operacoes) as valor_despesa_operacoes,
+from `basedosdados-perguntas.br_jota.eleicao_prestacao_contas_candidato_2024`
+group by 1, 2, 3, 4, 5, 6

--- a/models/br_jota/schema.yaml
+++ b/models/br_jota/schema.yaml
@@ -32,14 +32,73 @@ models:
       - name: rank_cargo_partido
       - name: receita_partido
       - name: valor_total
-  - name: eleicao_prestacao_contas_candidato_origem_2022
-    description: 'Informações de prestação de contas no nível de candidato e da origem
-      da despesa ou receita '
+  - name: eleicao_perfil_candidato_2024
+    description: Descreve o perfil dos candidatos da eleição de 2024
     columns:
+      - name: sequencial
+      - name: ano_sequencial_candidato
+      - name: nome_urna
+      - name: sigla_partido
+      - name: cargo
+      - name: municipio
+      - name: sigla_uf
+      - name: genero
+      - name: raca
+      - name: idade
+      - name: faixa_etaria
+  - name: eleicao_prestacao_contas_candidato_2024
+    description: Informações de prestação de contas no nível de candidato
+    columns:
+      - name: sequencial
+      - name: ano_sequencial_candidato
+      - name: nome_urna
+      - name: sigla_partido
+      - name: cargo
+      - name: sigla_uf
+      - name: genero
+      - name: raca
+      - name: idade
+      - name: faixa_etaria
+      - name: rank_cargo
+      - name: rank_partido
+      - name: rank_cargo_municipio
+      - name: rank_cargo_partido
+      - name: proporcao_despesa_pessoal
+      - name: proporcao_despesa_publicidade
+      - name: proporcao_despesa_outros
+      - name: proporcao_despesa_operacoes
+      - name: receita_partido
+      - name: valor_receita_total
+      - name: valor_despesa_total
+      - name: valor_despesa_pessoal
+      - name: valor_despesa_publicidade
+      - name: valor_despesa_outros
+      - name: valor_despesa_operacoes
+  - name: eleicao_prestacao_contas_candidato_origem_2024
+    description: Informações de prestação de contas no nível de candidato Origem
+    columns:
+      - name: excluir
+      - name: data_conta
       - name: sequencial_candidato
       - name: ano_sequencial_candidato
       - name: receita_despesa
       - name: origem
       - name: valor
-      - name: ultima_atualizacao
+      - name: n_linhas
       - name: categoria
+  - name: eleicao_prestacao_contas_partido_2024
+    description: Informações de prestação de contas no nível de Partido da despesa
+      ou receita '
+    columns:
+      - name: municipio
+      - name: sigla_partido
+      - name: cargo
+      - name: genero
+      - name: raca
+      - name: faixa_etaria
+      - name: valor_receita_total
+      - name: valor_despesa_total
+      - name: valor_despesa_pessoal
+      - name: valor_despesa_publicidade
+      - name: valor_despesa_outros
+      - name: valor_despesa_operacoes


### PR DESCRIPTION
*Adicionar modelos para br_jota 2024"

# br_tse_eleicoes

Tabela|Linhas|Materialização |Referencia|
|:-:|:-:|:-:|:-:|
eleicao_perfil_candidato_2024|462157| 41.4 MB|[:link:][source]
eleicao_prestacao_contas_candidato_2024|461858| 74.46 MB|[:link:][source]
eleicao_prestacao_contas_candidato_origem_2024|388234|61.49 MB|[:link:][source]
eleicao_prestacao_contas_partido_2024|287046|28.03 MB|[:link:][source]



  
[source]: https://www.sigaodinheiro.org/