### PR TITLE
[dbt]br_tse_filiacao_partidaria__microdados_antigos, novo custom_test e macro

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -360,6 +360,9 @@ models:
     br_tse_eleicoes_2022:
       +materialized: table
       +schema: br_tse_eleicoes_2022
+    br_tse_filiacao_partidaria:
+      +materialized: table
+      +schema: br_tse_filiacao_partidaria
     example:
       +materialized: table  # Materialization type (table, table or incremental)
       +schema: example  # Overrides the default schema (defaults to what is set on profiles.yml)

--- a/macros/validate_date_range.sql
+++ b/macros/validate_date_range.sql
@@ -1,0 +1,25 @@
+{% macro validate_date_range(column_name, start_date, end_date=None) %}
+
+    {% if end_date is none %}
+        case
+            when {{ column_name }} is null
+            then null
+            when
+                date({{ column_name }}) >= date('{{ start_date }}')
+                and date({{ column_name }}) <= current_date()
+            then safe_cast({{ column_name }} as date)
+            else null
+        end
+    {% else %}
+        case
+            when {{ column_name }} is null
+            then null
+            when
+                date({{ column_name }}) >= date('{{ start_date }}')
+                and date({{ column_name }}) <= date('{{ end_date }}')
+            then safe_cast({{ column_name }} as date)
+            else null
+        end
+    {% endif %}
+
+{% endmacro %}

--- a/models/br_tse_filiacao_partidaria/br_tse_filiacao_partidaria__microdados_antigos.sql
+++ b/models/br_tse_filiacao_partidaria/br_tse_filiacao_partidaria__microdados_antigos.sql
@@ -1,0 +1,27 @@
+{{
+    config(
+        schema="br_tse_filiacao_partidaria",
+        alias="microdados_antigos",
+        materialized="table",
+        cluster_by=["sigla_uf"],
+    )
+}}
+
+select
+    safe_cast(sigla_partido as string) sigla_partido,
+    safe_cast(sigla_uf as string) sigla_uf,
+    safe_cast(id_municipio as string) id_municipio,
+    safe_cast(id_municipio_tse as string) id_municipio_tse,
+    safe_cast(zona as int64) zona,
+    safe_cast(secao as int64) secao,
+    safe_cast(titulo_eleitoral as string) titulo_eleitoral,
+    safe_cast(nome as string) nome,
+    ({{ validate_date_range("data_filiacao", "1980-01-01") }}) as data_filiacao,
+    safe_cast(situacao_registro as string) situacao_registro,
+    safe_cast(tipo_registro as string) tipo_registro,
+    {{ validate_date_range("data_processamento", "1980-01-01") }} as data_processamento,
+    {{ validate_date_range("data_desfiliacao", "1980-01-01") }} as data_desfiliacao,
+    {{ validate_date_range("data_cancelamento", "1980-01-01") }} as data_cancelamento,
+    {{ validate_date_range("data_regularizacao", "1980-01-01") }} as data_regularizacao,
+    safe_cast(motivo_cancelamento as string) motivo_cancelamento,
+from `basedosdados-staging.br_tse_filiacao_partidaria_staging.microdados_antigos` as t

--- a/models/br_tse_filiacao_partidaria/schema.yml
+++ b/models/br_tse_filiacao_partidaria/schema.yml
@@ -2,7 +2,7 @@
 version: 2
 models:
   - name: br_tse_filiacao_partidaria__microdados_antigos
-    description: Insert table description here
+    description: Microdados de filiação partidária do TSE.
     tests:
       - custom_not_null_proportion_multiple_columns:
           at_least: 0.10

--- a/models/br_tse_filiacao_partidaria/schema.yml
+++ b/models/br_tse_filiacao_partidaria/schema.yml
@@ -1,0 +1,71 @@
+---
+version: 2
+models:
+  - name: br_tse_filiacao_partidaria__microdados_antigos
+    description: Insert table description here
+    tests:
+      - custom_not_null_proportion_multiple_columns:
+          at_least: 0.10
+          ignore_values: [data_regularizacao]
+    columns:
+      - name: sigla_partido
+        description: Sigla do partido
+      - name: sigla_uf
+        description: Sigla da unidade da federação
+        tests:
+          - custom_relationships:
+              to: ref('br_bd_diretorios_brasil__uf')
+              field: sigla
+              ignore_values: [ZZ]
+      - name: id_municipio
+        description: ID Município - IBGE 7 Dígitos
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_brasil__municipio')
+              field: id_municipio
+      - name: id_municipio_tse
+        description: ID Município - TSE
+      - name: zona
+        description: Zona eleitoral
+      - name: secao
+        description: Seção eleitoral
+      - name: titulo_eleitoral
+        description: Título eleitoral
+      - name: nome
+        description: Nome
+      - name: data_filiacao
+        description: Data da filiação
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__data')
+              field: data.data
+      - name: situacao_registro
+        description: Situação do registro
+      - name: tipo_registro
+        description: Tipo de registro
+      - name: data_processamento
+        description: Data de processamento
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__data')
+              field: data.data
+      - name: data_desfiliacao
+        description: Data de desfiliação
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__data')
+              field: data.data
+      - name: data_cancelamento
+        description: Data de cancelamento
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__data')
+              field: data.data
+      - name: data_regularizacao
+        description: Data de regularização
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__data')
+              field: data.data
+      - name: motivo_cancelamento
+        description: Motivo de cancelamento

--- a/tests/generic/custom_null_proportion_multiple_columns.sql
+++ b/tests/generic/custom_null_proportion_multiple_columns.sql
@@ -1,0 +1,71 @@
+{% test custom_not_null_proportion_multiple_columns(
+    model, ignore_values, at_least=0.05
+) %}
+
+    {%- set columns = adapter.get_columns_in_relation(model) -%}
+    {% set suffix = "_nulls" %}
+    {% set pivot_columns_query %}
+
+        with null_counts as(
+
+            select
+                {% for column in columns -%}
+                {% if column.name not in ignore_values %}
+                SUM(CASE WHEN {{ column.name }} IS NULL THEN 1 ELSE 0 END) AS {{ column.name }}{{ suffix }},
+                {% endif %}
+                {%- endfor %}
+                count(*) as total_records
+                from {{ model }}
+        ),
+
+        pivot_columns as (
+
+            {% for column in columns -%}
+            {% if column.name not in ignore_values %}
+            select '{{ column.name }}' as column_name, {{ column.name }}{{ suffix }} as quantity, total_records
+            from null_counts
+            {% if not loop.last %}union all {% endif %}
+            {% endif %}
+            {%- endfor %}
+        ),
+
+        faulty_columns as (
+            select
+                *
+            from pivot_columns
+            where
+                quantity / total_records > (1 - {{ at_least }})
+
+
+        )
+        select * from faulty_columns
+    {% endset %}
+    with
+        validation_errors as (
+            {%- set errors = dbt_utils.get_query_results_as_dict(
+                pivot_columns_query
+            ) -%}
+    {% if errors["column_name"] != () %}
+                {% for e in errors["column_name"] | unique %}
+                    {{
+                        log(
+                            "LOG: Coluna com preenchimento menor que "
+                            ~ at_least * 100
+                            ~ "% ---> "
+                            ~ e
+                            ~ "  [FAIL]",
+                            info=True,
+                        )
+                    }}
+                    select '{{e}}' as column
+                    {% if not loop.last %}
+                        union all
+                    {% endif %}
+                {% endfor %}
+            )
+        select *
+        from validation_errors
+    {% else %}select 1 as column) select * from validation_errors where column != 1
+    {% endif %}
+
+{% endtest %}


### PR DESCRIPTION
# Objetivos:
- Adicionar `br_tse_filiacao_partidaria__microdados_antigos` renomeação do atual `microdados` em prod 
- Adicionar `custom_not_null_proportion_multiple_columns` #783
- Adicionar Macro `validate_date_range`

### br_tse_filiacao_partidaria
Tabela|Linhas|Materialização|
|:-:|:-:|:-:|
microdados_antigos|24666625| 2.67 GB|

# Detalhe dos testes
### Coluna: id_municipio_tse
Teste: `relationships` Diretorio Alvo: `br_bd_diretorios_brasil.municipio`

Situação: Temos 130 ids que não se relacionam com o nosso diretorio. Todos eles aparecem como ids referente alguma localização estranhageira.

Solução: Remoção do teste enquanto não for insertido os ids faltantes.

Query:
```sql
with child as (
    select id_municipio_tse as from_field
    from `basedosdados-dev`.`br_tse_filiacao_partidaria`.`microdados_antigos`
    where id_municipio_tse is not null
),
parent as (
    select id_municipio_tse as to_field
    from `basedosdados`.`br_bd_diretorios_brasil`.`municipio`
), falhas as (
  select
    distinct from_field

from child
left join parent
    on child.from_field = parent.to_field

where parent.to_field is null
)

select distinct sigla_uf
from `basedosdados-dev`.`br_tse_filiacao_partidaria`.`microdados_antigos`
where id_municipio_tse in (select * from falhas)
```

### Coluna: sigla_uf
Teste: `custom_relationships` Diretorio Alvo: `br_bd_diretorios_brasil.uf`

Situação: Sigla 'ZZ' não se encontra no diretorio.

Solução: Colocar 'ZZ' dentro dos valores a serém ignorados dentro do teste

Query:
```sql
with child as (
    select sigla_uf as from_field
    from `basedosdados-dev`.`br_tse_filiacao_partidaria`.`microdados_antigos`
    where sigla_uf is not null
),

parent as (
    select sigla as to_field
    from `basedosdados-dev`.`br_bd_diretorios_brasil`.`uf`
)

select
    distinct from_field

from child
left join parent
    on child.from_field = parent.to_field

where parent.to_field is null
```

### Aplicação `validate_date_range`

Nas colunas com datas tínhamos valores muito fora da realidade, foi aplicado um filtro para validar datas entre 1980 à o atual ano.
Anteriormente tinha como Max data o `9990-12-02` depois do `validate_date_range` temo o `2023-10-01`
Anteriormente tinha como Min data o `0001-01-01` depois do `validate_date_range` temo o `1980-01-01`

Coluna|Vazios Pre `validate_date_range`|Vazios Pos `validate_date_range`|Acrescimo De Vazios
|:-:|:-:|:-:|:-:|
data_filiacao |0 |140492 | 140492
data_regularizacao |24657353 |24657353 | 0
data_processamento |21702269 |21702269 | 0
data_desfiliacao |21137932 |21139903 | 1971
data_cancelamento |18165572 |18166139 | 567

### custom_not_null_proportion_multiple_columns

Coluna `data_regularizacao ` tem menos de 1% de preenchimento e foi colocada como coluna a ser ignorada pelo teste

| coluna              |   validos |   vazios |    total |   porcentagem_vazio |
|:--------------------|----------:|---------:|---------:|--------------------:|
| data_regularizacao  |      9272 | 24657353 | 24666625 |              0.9996 |
| data_processamento  |   2964356 | 21702269 | 24666625 |              0.8798 |
| data_desfiliacao    |   3526722 | 21139903 | 24666625 |              0.857  |
| motivo_cancelamento |   5183219 | 19483406 | 24666625 |              0.7899 |
| data_cancelamento   |   6500486 | 18166139 | 24666625 |              0.7365 |

**CSV com preenchimento completo da tabela ➡️ [:file_folder:][microdados_antigos]**

### Teste: unique_combination_of_columns

Situação: Apos aplicação do filtro de validação de datas entre 1980 à atual, existem `data_filiacao` que são nulos. O que faz ter linhas duplicadas. Invalidando o teste de `unique_combination_of_columns`

Query:

Podemos ver com a query abaixo que a única coisa que diferencia entre algumas linhas da consulta é a `data_filiacao`. (Dados antes de qualquer tratamento)

```sql
select *
FROM `basedosdados-dev.br_tse_filiacao_partidaria_staging.microdados_antigos`
where titulo_eleitoral = "018345602739"
```


[microdados_antigos]: https://github.com/user-attachments/files/17338630/br_tse_filiacao_partidaria__microdados_antigos.csv