### PR TITLE
[dados]br_tse_filiacao_partidaria.microdados

### DIFF
--- a/models/br_tse_filiacao_partidaria/br_tse_filiacao_partidaria__microdados.sql
+++ b/models/br_tse_filiacao_partidaria/br_tse_filiacao_partidaria__microdados.sql
@@ -1,0 +1,51 @@
+{{
+    config(
+        schema="br_tse_filiacao_partidaria",
+        alias="microdados",
+        materialized="table",
+        unique_key="registro_filiacao",
+        partition_by={
+            "field": "data_extracao",
+            "data_type": "date",
+        },
+        cluster_by=["sigla_uf"],
+    )
+}}
+with
+    tabela as (
+        select
+            safe_cast(sqregistrofiliacao as string) registro_filiacao,
+            safe_cast(sgpartido as string) sigla_partido,
+            safe_cast(sigla_uf as string) sigla_uf,
+            safe_cast(id_municipio as string) id_municipio,
+            safe_cast(codlocalidadetse as string) id_municipio_tse,
+            safe_cast(numzona as string) zona,
+            safe_cast(numsecao as string) secao,
+            safe_cast(nrtituloeleitor as string) titulo_eleitor,
+            safe_cast(numcpf as string) cpf,
+            safe_cast(nmeleitor as string) nome,
+            safe_cast(nmsocialeleitor as string) nome_social,
+            safe_cast(tpsexo as string) sexo,
+            safe_cast(dessituacaoeleitor as string) situacao_registro,
+            safe_cast(cdmotivodesfiliacao as string) motivo_desfiliacao,
+            safe_cast(cdmotivocancelamento as string) motivo_cancelamento,
+            safe_cast(indorigem as string) indicador_origem,
+            safe_cast(dtfiliacao as date) data_filiacao,
+            safe_cast(dtdesfiliacao as date) data_desfiliacao,
+            safe_cast(tscadastrodesfiliacao as date) data_cadastro_desfiliacao,
+            safe_cast(dtcancelamento as date) data_cancelamento,
+            safe_cast(dtexclusao as date) data_exclusao,
+            safe_cast(data_extracao as date) data_extracao,
+        from `basedosdados-staging.br_tse_filiacao_partidaria_staging.microdados`
+    ),
+    select_rows as (
+        select
+            *,
+            row_number() over (
+                partition by registro_filiacao order by data_extracao desc
+            ) as rn
+        from tabela
+    )
+select * except (rn)
+from select_rows
+where rn = 1

--- a/models/br_tse_filiacao_partidaria/schema.yml
+++ b/models/br_tse_filiacao_partidaria/schema.yml
@@ -2,7 +2,7 @@
 version: 2
 models:
   - name: br_tse_filiacao_partidaria__microdados_antigos
-    description: Microdados de filiação partidária do TSE.
+    description: Microdados antigos de filiação partidária do TSE.
     tests:
       - custom_not_null_proportion_multiple_columns:
           at_least: 0.10
@@ -69,3 +69,98 @@ models:
               field: data.data
       - name: motivo_cancelamento
         description: Motivo de cancelamento
+  - name: br_tse_filiacao_partidaria__microdados
+    description: Microdados de filiação partidária do TSE.
+    tests:
+      - custom_not_null_proportion_multiple_columns:
+          at_least: 0.55
+          ignore_values:
+            - data_desfiliacao
+            - data_exclusao
+            - data_cadastro_desfiliacao
+            - motivo_desfiliacao
+            - motivo_cancelamento
+            - data_cancelamento
+            - nome_social
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [registro_filiacao]
+    columns:
+      - name: registro_filiacao
+        description: Sequecia do registro filiação
+      - name: sigla_partido
+        description: Sigla do partido
+      - name: sigla_uf
+        description: Sigla da unidade da federação
+        tests:
+          - custom_relationships:
+              to: ref('br_bd_diretorios_brasil__uf')
+              field: sigla
+              ignore_values: [ZZ]
+      - name: id_municipio
+        description: ID Município - IBGE 7 Dígitos
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_brasil__municipio')
+              field: id_municipio
+      - name: id_municipio_tse
+        description: ID Município - TSE
+      - name: zona
+        description: Zona eleitoral
+      - name: secao
+        description: Seção eleitoral
+      - name: titulo_eleitor
+        description: Título de eleitor
+      - name: cpf
+        description: Cadastro de pessoa física
+      - name: nome
+        description: Nome do eleitor
+      - name: nome_social
+        description: Nome social do eleitor
+      - name: sexo
+        description: Sexo
+      - name: situacao_registro
+        description: Situação do registro
+      - name: motivo_desfiliacao
+        description: Código do motivo da desfiliação. Não foi encontrada na documentação
+          a tradução deste código
+      - name: motivo_cancelamento
+        description: Código do motivo de cancelamento. Não foi encontrada na documentação
+          a tradução deste código
+      - name: indicador_origem
+        description: Não foi encontrado uma definição na documentação para este campo
+      - name: data_filiacao
+        description: Data da filiação
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__data')
+              field: data.data
+      - name: data_desfiliacao
+        description: Data de desfiliação
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__data')
+              field: data.data
+      - name: data_cadastro_desfiliacao
+        description: Data do cadastro da desfiliação
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__data')
+              field: data.data
+      - name: data_cancelamento
+        description: Data de cancelamento
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__data')
+              field: data.data
+      - name: data_exclusao
+        description: Data de exclusão
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__data')
+              field: data.data
+      - name: data_extracao
+        description: Data de extração da linha
+        tests:
+          - relationships:
+              to: ref('br_bd_diretorios_data_tempo__data')
+              field: data.data


### PR DESCRIPTION
# Objetivos:
- Adicionar `br_tse_filiacao_partidaria__microdados` e seus testes

### br_tse_filiacao_partidaria
Tabela|Linhas|Materialização|Arquitetura
|:-:|:-:|:-:|:-:|
microdados|17173906| 3.4 GiB|[🔗 ][arquitetura]

# Detalhe dos testes
### Coluna: id_municipio_tse
Teste: `relationships` Diretorio Alvo: `br_bd_diretorios_brasil.municipio`

Situação: Temos 130 ids que não se relacionam com o nosso diretorio. Todos eles aparecem como ids referente alguma localização estranhageira.

Solução: Remoção do teste enquanto não for insertido os ids faltantes.

### Coluna: sigla_uf
Teste: `custom_relationships` Diretorio Alvo: `br_bd_diretorios_brasil.uf`

Situação: Sigla 'ZZ' não se encontra no diretorio.

Solução: Colocar 'ZZ' dentro dos valores a serém ignorados dentro do teste

### custom_not_null_proportion_multiple_columns

Coluna `data_exclusao, nome_social, data_cancelamento, motivo_cancelamento, data_cadastro_desfiliacao` e outras tem menos de 1% de preenchimento e foi colocada como coluna a ser ignorada pelo teste

| coluna                    |   validos |   vazios |    total |   porcentagem_vazio |
|:--------------------------|----------:|---------:|---------:|--------------------:|
| data_exclusao             |      2061 | 17171845 | 17173906 |              0.9999 |
| nome_social               |      2236 | 17171670 | 17173906 |              0.9999 |
| data_cancelamento         |     12801 | 17161105 | 17173906 |              0.9993 |
| motivo_cancelamento       |     13573 | 17160333 | 17173906 |              0.9992 |
| data_cadastro_desfiliacao |     15786 | 17158120 | 17173906 |              0.9991 |

**CSV com preenchimento completo da tabela ➡️ [:file_folder:][file_folder]**

[file_folder]: https://github.com/user-attachments/files/17462756/br_tse_filiacao_partidaria__microdados.csv
[arquitetura]: https://docs.google.com/spreadsheets/d/1XZ8wtysRTjos9jXY_wiFfBBwiiFuLb0I/edit?gid=2114907888#gid=2114907888
