### PR TITLE
[Refactor] custom_dicionary_coverage

### DIFF
--- a/tests/generic/custom_dictionary_coverage.sql
+++ b/tests/generic/custom_dictionary_coverage.sql
@@ -6,7 +6,13 @@
 
     {%- set combined_query_parts = [] -%}
     {%- set union_parts = [] -%}
-    {% set table_id = model.identifier %}
+
+    {% set model_sql = model | string %}
+    {% set start = model_sql.find("`") + 1 %}
+    {% set end = model_sql.rfind("`") %}
+    {% set full_path = model_sql[start:end] %}
+    {% set path_parts = full_path.split(".") %}
+    {% set table_id = path_parts[2].replace("`", "").strip() %}
 
     {%- for column_name in columns_covered_by_dictionary %}
         {% set subquery_name = "exceptions_" ~ loop.index %}


### PR DESCRIPTION
## Descrição do PR:
Este PR refatora o teste custom_dictionary_coverage que não reconhecia o table_id da objeto model do DBT e compilava o teste tem o table_id da tabela a ser testada.

## Detalhes Técnicos:
ver #826 

## Teste e Validações:

  - [x]  Testado em `queries-basedosdados-dev`
  
 teste feito nas tabelas br_e_comex_stat.ncm_exportacao & br_rf_cno.vinculos
