### PR TITLE
[fix]Fixando versão do poetry temporariamente

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -64,7 +64,7 @@ jobs:
         with:
           separator: ','
       - name: Set up poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.5
       - name: Set up python
         uses: actions/setup-python@v4
         with:
@@ -88,7 +88,7 @@ jobs:
         with:
           separator: ','
       - name: Set up poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.5
       - name: Set up python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/ci-dbt.yaml
+++ b/.github/workflows/ci-dbt.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.5
       - name: Set up python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.5
       - name: Set up python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/sync-dbt-schema.yaml
+++ b/.github/workflows/sync-dbt-schema.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           separator: ','
       - name: Set up poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.5
       - name: Set up python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test_dbt_model.yaml
+++ b/.github/workflows/test_dbt_model.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           separator: ','
       - name: Set up poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.5
       - name: Set up python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/triggers-elementary-model.yaml
+++ b/.github/workflows/triggers-elementary-model.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
       - name: Set up poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.5
       - name: Set up python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
# Fixando versão do poetry temporariamente

## Descrição do PR:
 Estamos temporariamente fixando a versão do poetry para 1.8.5, porque a versão 2.0.0 está quebrando nosso [teste][test].
Isso é apenas para não travar a fila de PR, enquanto buscamos uma solução mais completa.




[test]: https://github.com/basedosdados/queries-basedosdados/actions/runs/12653167251/job/35257721570