### PR TITLE
[Refactor]Retornando cd.yaml para 'on pull_request e desativando 'change-metada'

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,8 +1,8 @@
 ---
 name: CD
 on:
-  push:
-    branches: [main]
+  pull_request:
+    types: [closed]
 env:
   GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
   GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
@@ -15,6 +15,9 @@ env:
   IMAGE_NAME: ghcr.io/basedosdados/queries-basedosdados
 jobs:
   build-container:
+    if: |
+      github.event.pull_request.merged == true
+      && github.event.pull_request.base.ref == 'main'
     name: Deployment
     runs-on: ubuntu-latest
     steps:
@@ -72,27 +75,27 @@ jobs:
       - name: Run script for approving table
         run: |
           poetry run python .github/workflows/scripts/table_approve.py --modified-files ${{ steps.changed-files.outputs.all_modified_files }} --graphql-url ${{ secrets.BACKEND_GRAPHQL_URL }} --source-bucket-name ${{ secrets.SOURCE_BUCKET_NAME }} --destination-bucket-name ${{ secrets.DESTINATION_BUCKET_NAME }} --backup-bucket-name ${{ secrets.BACKUP_BUCKET_NAME }} --prefect-backend-token ${{ secrets.PREFECT_BACKEND_TOKEN }} --materialization-mode ${{ secrets.MATERIALIZATION_MODE }} --materialization-label ${{ secrets.MATERIALIZATION_LABEL }}
-  change-metadata-status:
-    needs: table-approve
-    name: Change metadata status to "production"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Get all changed files using a comma separator
-        id: changed-files
-        uses: tj-actions/changed-files@v35
-        with:
-          separator: ','
-      - name: Set up poetry
-        run: pipx install poetry==1.8.5
-      - name: Set up python
-        uses: actions/setup-python@v4
-        with:
-          cache: poetry
-          python-version: '3.9'
-      - name: Install requirements
-        run: poetry install --only=dev
-      - name: Run script for changing metadata status
-        run: |-
-          poetry run python .github/workflows/scripts/change_metadata_status.py --modified-files ${{ steps.changed-files.outputs.all_modified_files }} --graphql-url ${{ secrets.BACKEND_GRAPHQL_URL }} --status published --email ${{ secrets.BACKEND_EMAIL }} --password ${{ secrets.BACKEND_PASSWORD }}
+  # change-metadata-status:
+  #   needs: table-approve
+  #   name: Change metadata status to "production"
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Get all changed files using a comma separator
+  #       id: changed-files
+  #       uses: tj-actions/changed-files@v35
+  #       with:
+  #         separator: ','
+  #     - name: Set up poetry
+  #       run: pipx install poetry==1.8.5
+  #     - name: Set up python
+  #       uses: actions/setup-python@v4
+  #       with:
+  #         cache: poetry
+  #         python-version: '3.9'
+  #     - name: Install requirements
+  #       run: poetry install --only=dev
+  #     - name: Run script for changing metadata status
+  #       run: |-
+  #         poetry run python .github/workflows/scripts/change_metadata_status.py --modified-files ${{ steps.changed-files.outputs.all_modified_files }} --graphql-url ${{ secrets.BACKEND_GRAPHQL_URL }} --status published --email ${{ secrets.BACKEND_EMAIL }} --password ${{ secrets.BACKEND_PASSWORD }}


### PR DESCRIPTION
## Retornando cd.yaml para 'on pull_request e desativando 'change-metada'

### Descrição do PR:

Infelizmente mais alterações serão necessarias para consegui rodar `cd.yaml` com: 

```yaml
on:
  push:
    branches: [main]
```
Vamos retorna para a versão antiga e desativar a função atualmente quebrada do `change-metadata-status`

