### PR TITLE
[Refactor]Modificando log not_null_proportion_multiple_columns

### DIFF
--- a/tests/generic/not_null_proportion_multiple_columns.sql
+++ b/tests/generic/not_null_proportion_multiple_columns.sql
@@ -69,6 +69,7 @@
                             " - "
                             ~ colors.vermelho
                             ~ "Coluna totalmente vazia!"
+                            ~ colors.reset
                         ) %}
                     {% endif %}
 
@@ -76,18 +77,18 @@
                         log(
                             "Coluna: "
                             ~ e
-                            ~ " - Quantidade: "
+                            ~ " - Resultado: "
+                            ~ colors.vermelho
+                            ~ "FAIL"
+                            ~ colors.reset
+                            ~ recommended_message
+                            ~ " - Quantidade Null: "
                             ~ errors["quantity"][loop.index0]
                             ~ " - Total: "
                             ~ errors["total_records"][loop.index0]
                             ~ " - Proporção Null: "
                             ~ "%0.2f"
-                            | format(proc_err | float)
-                            ~ recommended_message
-                            ~ " - Resultado: "
-                            ~ colors.vermelho
-                            ~ "FAIL"
-                            ~ colors.reset,
+                            | format(proc_err | float),
                             info=True,
                         )
                     }}

--- a/tests/generic/not_null_proportion_multiple_columns.sql
+++ b/tests/generic/not_null_proportion_multiple_columns.sql
@@ -41,15 +41,53 @@
     {% if errors["column_name"] != () %}
                 {% for e in errors["column_name"] | unique %}
 
+                    {%- set colors = {
+                        "vermelho": "\033[31m",
+                        "amarelo": "\033[33m",
+                        "reset": "\033[0m",
+                    } %}
+
                     {% set proc_err = (
                         errors["quantity"][loop.index0]
                         / errors["total_records"][loop.index0]
                     ) * 100 %}
 
+                    {% set recommended_at_least = 0.99 - (
+                        errors["quantity"][loop.index0] | float
+                    ) / (errors["total_records"][loop.index0] | float) %}
+
+                    {%- set recommended_message = (
+                        " - "
+                        ~ colors.amarelo
+                        ~ "'at_least' Recomendado: "
+                        ~ "%0.2f"
+                        | format(recommended_at_least | float) ~ colors.reset
+                    ) %}
+
+                    {% if recommended_at_least <= 0.0 %}
+                        {%- set recommended_message = (
+                            " - "
+                            ~ colors.vermelho
+                            ~ "Coluna totalmente vazia!"
+                        ) %}
+                    {% endif %}
+
                     {{
                         log(
-                            "Coluna: " ~ e ~ " - Preenchimento de: " ~ "%0.2f"
-                            | format(proc_err | float) ~ "% - Resultado: FAIL",
+                            "Coluna: "
+                            ~ e
+                            ~ " - Quantidade: "
+                            ~ errors["quantity"][loop.index0]
+                            ~ " - Total: "
+                            ~ errors["total_records"][loop.index0]
+                            ~ " - Proporção Null: "
+                            ~ "%0.2f"
+                            | format(proc_err | float)
+                            ~ recommended_message
+                            ~ " - Resultado: "
+                            ~ colors.vermelho
+                            ~ "FAIL"
+                            ~ colors.reset,
                             info=True,
                         )
                     }}


### PR DESCRIPTION
# [Refactor]Modificando log not_null_proportion_multiple_columns

## Atual Log
![image](https://github.com/user-attachments/assets/91aa9a56-3f18-4136-b2a8-c4d181a8cdec)

- `Preenchimento` não deixava claro que estamos falando da proporção de linhas vazias na tabela
- `Preenchimento ideal` não traz nenhuma informação nova. Apenas enfatiza o valor colocado em `at_least`
## Novo Log
### Casos onde o `at_least` está maior do que a coluna consegui preencher
![image](https://github.com/user-attachments/assets/65d0757c-1dd6-477d-a5e0-797b3043b907)
### Casos onde a coluna está totalmente vazia
![image](https://github.com/user-attachments/assets/151ad963-68b1-4752-a5f6-8744643ad4b9)



- ` Proporção Null` indica melhor que a o numero é referente a proporção de linhas vazias na tabela
- `'at_least' Recomendado` agora indica o valor que `at_least` precisa ter para que o test tenha sucesso nessa coluna
- `Qualidade` renomeado para `Qualidade Null`
- Caso a coluna esteja totalmente vazia. Um aviso vai ser destacado,
- Foi colocado cor para realçar a recomendação de `'at_least' Recomendado`
- Cor vermelha no texto `FAIL` para deixa claro que apesar da cor amarela da recomendação, essa coluna falhou no teste
