### PR TITLE
[Fix]Remoção de colunas excessivas - br_inpe_queimadas__microdados

### DIFF
--- a/models/br_inpe_queimadas/br_inpe_queimadas__microdados.sql
+++ b/models/br_inpe_queimadas/br_inpe_queimadas__microdados.sql
@@ -16,10 +16,6 @@ select distinct
     safe_cast(f.longitude as float64) longitude,
     safe_cast(f.ano as int64) ano,
     safe_cast(f.mes as int64) mes,
-    safe_cast(f.dia as int64) dia,
-    safe_cast(f.hora as int64) hora,
-    safe_cast(f.minuto as int64) minuto,
-    safe_cast(f.segundo as int64) segundo,
     datetime(
         safe_cast(ano as int64),
         safe_cast(mes as int64),

--- a/models/br_inpe_queimadas/schema.yaml
+++ b/models/br_inpe_queimadas/schema.yaml
@@ -9,12 +9,7 @@ models:
           combination_of_columns:
             - latitude
             - longitude
-            - ano
-            - mes
-            - dia
-            - hora
-            - minuto
-            - segundo
+            - data_hora
             - potencia_radiativa_fogo
       - not_null_proportion_multiple_columns:
           at_least: 0.70
@@ -39,34 +34,6 @@ models:
           - relationships:
               to: ref('br_bd_diretorios_data_tempo__mes')
               field: mes.mes
-      - name: dia
-        description: Dia de referência da passagem do satélite segundo o fuso horário
-          de Greenwich (GMT).
-        tests:
-          - relationships:
-              to: ref('br_bd_diretorios_data_tempo__dia')
-              field: dia.dia
-      - name: hora
-        description: Hora de referência da passagem do satélite segundo o fuso horário
-          de Greenwich (GMT).
-        tests:
-          - relationships:
-              to: ref('br_bd_diretorios_data_tempo__hora')
-              field: hora.hora
-      - name: minuto
-        description: Minuto de referência da passagem do satélite segundo o fuso horário
-          de Greenwich (GMT).
-        tests:
-          - relationships:
-              to: ref('br_bd_diretorios_data_tempo__minuto')
-              field: minuto.minuto
-      - name: segundo
-        description: Segundo de referência da passagem do satélite segundo o fuso
-          horário de Greenwich (GMT).
-        tests:
-          - relationships:
-              to: ref('br_bd_diretorios_data_tempo__segundo')
-              field: segundo.segundo
       - name: data_hora
         description: Coluna agregada de data e hora da passagem do satélite o fuso
           horário de Greenwich (GMT).


### PR DESCRIPTION
[Fix]Remoção de colunas excessivas - br_inpe_queimadas__microdados

## Descrição do PR:

Algumas colunas excessivas estão sendo removidas para uma melhor leitura e utilização dos dados

Colunas removidas:

- dia
- hora
- minuto
- segundo


