### PR TITLE
[Fix] Atualizar upload-artifact em elementary.yml

### DIFF
--- a/.github/workflows/elementary.yaml
+++ b/.github/workflows/elementary.yaml
@@ -24,13 +24,13 @@ jobs:
           bigquery-keyfile: ${{ secrets.BIGQUERY_KEYFILE }}
           gcs-keyfile: ${{ secrets.GCS_KEYFILE }}
       - name: Upload report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: report.html
           path: report.html
       - name: Upload log
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: edr.log
           path: edr.log


### PR DESCRIPTION
# [Fix] Atualizar upload-artifact em elementary.yml

## Atualizar upload-artifact em elementary.yml
> [!WARNING]
> actions/upload-artifact@v3 is scheduled for deprecation on **November 30, 2024**. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
> Similarly, v1/v2 are scheduled for deprecation on **June 30, 2024**.
> Please update your workflow to use v4 of the artifact actions.
> This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers.

### Teste em DEV -> [⚙️](https://github.com/basedosdados/queries-basedosdados-dev/actions/runs/13593554572/job/38005197074)
