### PR TITLE
[Refactor] Mudando cd.yaml para pull_request_target

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,8 +1,9 @@
 ---
 name: CD
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
+    branches: [main]
 env:
   GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
   GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
@@ -73,29 +74,5 @@ jobs:
       - name: Install requirements
         run: poetry install --only=dev
       - name: Run script for approving table
-        run: |
+        run: |-
           poetry run python .github/workflows/scripts/table_approve.py --modified-files ${{ steps.changed-files.outputs.all_modified_files }} --graphql-url ${{ secrets.BACKEND_GRAPHQL_URL }} --source-bucket-name ${{ secrets.SOURCE_BUCKET_NAME }} --destination-bucket-name ${{ secrets.DESTINATION_BUCKET_NAME }} --backup-bucket-name ${{ secrets.BACKUP_BUCKET_NAME }} --prefect-backend-token ${{ secrets.PREFECT_BACKEND_TOKEN }} --materialization-mode ${{ secrets.MATERIALIZATION_MODE }} --materialization-label ${{ secrets.MATERIALIZATION_LABEL }}
-  # change-metadata-status:
-  #   needs: table-approve
-  #   name: Change metadata status to "production"
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #     - name: Get all changed files using a comma separator
-  #       id: changed-files
-  #       uses: tj-actions/changed-files@v35
-  #       with:
-  #         separator: ','
-  #     - name: Set up poetry
-  #       run: pipx install poetry==1.8.5
-  #     - name: Set up python
-  #       uses: actions/setup-python@v4
-  #       with:
-  #         cache: poetry
-  #         python-version: '3.9'
-  #     - name: Install requirements
-  #       run: poetry install --only=dev
-  #     - name: Run script for changing metadata status
-  #       run: |-
-  #         poetry run python .github/workflows/scripts/change_metadata_status.py --modified-files ${{ steps.changed-files.outputs.all_modified_files }} --graphql-url ${{ secrets.BACKEND_GRAPHQL_URL }} --status published --email ${{ secrets.BACKEND_EMAIL }} --password ${{ secrets.BACKEND_PASSWORD }}


### PR DESCRIPTION
# [Refactor] Mudando cd.yaml para pull_request_target

**Essa seria a opção com menor alteração que pensei. Mas sem duvidas podemos tentar outra coisa caso algum desconforto com a solução**

Esse PR abre a possibilidade para que possamos entrar no caminho mais [padrão de contribuição do github][fork_git].
Existe algumas opções para que possamos realizar essa tarefa. Mas acredito que utilizar [`pull_request_target`][doc_pull_request_target] faça isso com pouquíssima alteração no script [`cd.yaml`][cd_yaml].

```yaml
  pull_request_target:
    types: [closed]
    branches: [main]
```
## Segurança com [`pull_request_target`][doc_pull_request_target]

Normalmente usar [`pull_request_target`][doc_pull_request_target] vem com uma maior cautela em relação a segurança.
> [!WARNING]
> Para os fluxos de trabalho que são disparados pelo evento pull_request_target, o GITHUB_TOKEN recebe a permissão de leitura/gravação no repositório, a menos que a chave permissions seja especificada e o fluxo de trabalho possa acessar segredos, mesmo quando ela for disparada em um fork. Embora o fluxo de trabalho seja executado no contexto da base da pull request, você deve certificar-se de que você não irá fazer checkout, construir ou executar o código não confiável da pull request com este evento. Além disso, qualquer cache compartilha o mesmo escopo do ramo de base. Para evitar envenenamento do cache, você não deve salvar o cache se houver a possibilidade de que o conteúdo do cache tenha sido alterado. Para obter mais informações, confira [Como manter o GitHub Actions e seus fluxos de trabalho seguros: impedir solicitações pwn](https://securitylab.github.com/research/github-actions-preventing-pwn-requests) no site do GitHub Security Lab.

Mas em nosso caso acredito na viabilidade de forma segura da utilização do [`pull_request_target`][doc_pull_request_target].
Ninguém conseguiria iniciar nossa action com [`cd.yaml`][cd_yaml] sem uma revisão previa de algum membro da equipe. Afinal ela está com `types: [closed]`, `branches: [main]` e `github.event.pull_request.merged == true`

Componentes importantes:

    types: [closed]
        - O workflow só será executado quando o pull request for fechado
        - Isso garante que o código já passou por revisão e foi aprovado
        - Previne execução durante o processo de revisão
    branches: [main]
        - O workflow só será executado quando o pull request estiver direcionado para a branch main
        - Garante que apenas mudanças para a branch principal acionem o workflow
        - Previne execução acidental em branches de desenvolvimento

Benefícios de Segurança

    Controle de Execução
        - O workflow só é executado após a aprovação e mesclagem do código
        - Evita execução durante o processo de revisão
        - Garante que apenas código aprovado e pronto para produção seja executado
    Fluxo de Segurança
        - Revisão de código obrigatória antes da execução
        - Validação completa do código antes do acesso aos secrets
        - Menor risco de execução maliciosa durante o processo de revisão

## Requisito recomendados antes do merge desse pull request.

Antes de fazer o merge desse pull request acho importante garantimos algumas mudanças nas configurações do repositório para uma maior segurança. Ainda mais com a nova possibilidade de PRs vindo de forks.

Em `Settings` -> `Actions` -> `General` . Ativar a opção que qualquer usuário que não faça parte da equipe desse repositório. Necessite de aprovação para que qualquer action seja ativada.

![image](https://github.com/user-attachments/assets/9cba811f-4d8c-4cb2-9b56-8a5fadcf3a7d)
  


[fork_git]: https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-a-project#about-forking
[cd_yaml]: https://github.com/basedosdados/queries-basedosdados/blob/main/.github/workflows/cd.yaml
[doc_pull_request_target]: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target