### PR TITLE
[bug] br_cgu_servidores_executivo_federal.remuneracao

### DIFF
--- a/models/br_cgu_servidores_executivo_federal/br_cgu_servidores_executivo_federal__remuneracao.sql
+++ b/models/br_cgu_servidores_executivo_federal/br_cgu_servidores_executivo_federal__remuneracao.sql
@@ -19,7 +19,7 @@
 select
     safe_cast(ano as int64) ano,
     safe_cast(mes as int64) mes,
-    safe_cast(id_servidor as string) id_servidor,
+    safe_cast(replace(id_servidor, ".0", "") as string) id_servidor,
     safe_cast(cpf as string) cpf,
     safe_cast(nome as string) nome,
     safe_cast(


### PR DESCRIPTION
## Descrição do PR:
- Um usuário relatou um erro na tabela de remuneração. Apenas removi os .0 do id_servidor para resolver essa questão.
Mensagem do usuário:

Mensagem do usuário:
Olá pessoal, 
fiz uma query para puxar os dados dos servidores puxando a tabela "reumuneração"  e "cadastro servidores". Fiz a consulta para ano = 2023,  mes = 12. Ao tentar fazer um join utilizando a variável id_servidor, identifiquei que os dados da tabela "remuneração" estão com digitos a mais, terminando em ".0". Não verifiquei outros anos e meses. Acredito que pelo tratamento da BD essas variáveis deveriam estar harmonizadas, correto? Obrigado. Raphael
