### PR TITLE
[Refactor] models

### DIFF
--- a/macros/set_datalake_project.sql
+++ b/macros/set_datalake_project.sql
@@ -1,0 +1,11 @@
+{% macro set_datalake_project(table_path) %}
+    {% if target.name == "dev" %} {% set prefix = "basedosdados-dev" %}
+    {% elif target.name == "prod" %} {% set prefix = "basedosdados-staging" %}
+    {% else %}
+        {% do exceptions.raise_compiler_error(
+            "Invalid target: " ~ target.name ~ ". Use 'dev' or 'prod'."
+        ) %}
+    {% endif %}
+
+    `{{ prefix }}.{{ table_path }}`
+{% endmacro %}


### PR DESCRIPTION

## Descrição do PR:
- Este PR adiciona a macro set_datalake_project com objetivo de permitir a escolha de qual projeto no datalake (basedosdados-dev_staging ou basedosdados-staging) os modelos devem consumir os dados. 
- A macro infere o projeto a partir do parâmetro target passado no comando de run. Quando o valor é 'dev', o modelo consome dados de dev. Quando o valor é 'prod', o modelo consome dados de basedosdados-staging.
- Esta modificação é necessária em virtude da unificação dos modelos no repositório queries-basedosdados
