### PR TITLE
[chore]: udpate gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,9 @@ dbt_packages/
 __pycache__/
 .python-version
 #
-models/*/tmp/
-models/*/input/
-models/*/output/
-models/*/extra/
+models/**/tmp/
+models/**/input/
+models/**/output/
+models/**/extra/
 venv*
 edr_target/


### PR DESCRIPTION
# Descrição

Ignorando subpastas dentro da pasta `models/`. As vezes `input/` fica dentro da pasta `code/`